### PR TITLE
feat(PR-5): Implement OCR text normalization v1

### DIFF
--- a/lib/services/text_normalize_options.dart
+++ b/lib/services/text_normalize_options.dart
@@ -1,0 +1,138 @@
+/// OCRテキスト整形のオプション設定
+class TextNormalizeOptions {
+  /// 英数記号の半角化（全角→半角）
+  final bool normalizeAsciiWidth;
+
+  /// 日本語句読点の統一（, . → 、 。）
+  final bool unifyJaPunct;
+
+  /// 引用符の統一（" " → 「 」（日本語行のみ））
+  final bool unifyQuotes;
+
+  /// 行頭・行末の空白削除
+  final bool trimSpaces;
+
+  /// 連続スペースの圧縮（複数→1個）
+  final bool collapseSpaces;
+
+  /// 和欧境界のスペース挿入（東京2025 → 東京 2025）
+  final bool manageJaEnBoundaries;
+
+  /// ダッシュ/長音の正規化（— – → ー または -）
+  final bool normalizeDashes;
+
+  /// 中黒の統一（･ • → ・）
+  final bool normalizeBullets;
+
+  /// 改行ルールの適用（3連以上→2つまで）
+  final bool linebreakRules;
+
+  /// 末尾句読点の連続正規化（。。 → 。）
+  final bool normalizeEndPunctuation;
+
+  const TextNormalizeOptions({
+    this.normalizeAsciiWidth = true,
+    this.unifyJaPunct = true,
+    this.unifyQuotes = true,
+    this.trimSpaces = true,
+    this.collapseSpaces = true,
+    this.manageJaEnBoundaries = true,
+    this.normalizeDashes = true,
+    this.normalizeBullets = true,
+    this.linebreakRules = true,
+    this.normalizeEndPunctuation = true,
+  });
+
+  /// デフォルト設定（すべて有効）
+  static const TextNormalizeOptions defaultOptions = TextNormalizeOptions();
+
+  /// 最小限の設定（基本的な整形のみ）
+  static const TextNormalizeOptions minimalOptions = TextNormalizeOptions(
+    normalizeAsciiWidth: true,
+    trimSpaces: true,
+    collapseSpaces: true,
+    unifyJaPunct: false,
+    unifyQuotes: false,
+    manageJaEnBoundaries: false,
+    normalizeDashes: false,
+    normalizeBullets: false,
+    linebreakRules: false,
+    normalizeEndPunctuation: false,
+  );
+
+  /// カスタム設定のコピー
+  TextNormalizeOptions copyWith({
+    bool? normalizeAsciiWidth,
+    bool? unifyJaPunct,
+    bool? unifyQuotes,
+    bool? trimSpaces,
+    bool? collapseSpaces,
+    bool? manageJaEnBoundaries,
+    bool? normalizeDashes,
+    bool? normalizeBullets,
+    bool? linebreakRules,
+    bool? normalizeEndPunctuation,
+  }) {
+    return TextNormalizeOptions(
+      normalizeAsciiWidth: normalizeAsciiWidth ?? this.normalizeAsciiWidth,
+      unifyJaPunct: unifyJaPunct ?? this.unifyJaPunct,
+      unifyQuotes: unifyQuotes ?? this.unifyQuotes,
+      trimSpaces: trimSpaces ?? this.trimSpaces,
+      collapseSpaces: collapseSpaces ?? this.collapseSpaces,
+      manageJaEnBoundaries: manageJaEnBoundaries ?? this.manageJaEnBoundaries,
+      normalizeDashes: normalizeDashes ?? this.normalizeDashes,
+      normalizeBullets: normalizeBullets ?? this.normalizeBullets,
+      linebreakRules: linebreakRules ?? this.linebreakRules,
+      normalizeEndPunctuation:
+          normalizeEndPunctuation ?? this.normalizeEndPunctuation,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is TextNormalizeOptions &&
+        other.normalizeAsciiWidth == normalizeAsciiWidth &&
+        other.unifyJaPunct == unifyJaPunct &&
+        other.unifyQuotes == unifyQuotes &&
+        other.trimSpaces == trimSpaces &&
+        other.collapseSpaces == collapseSpaces &&
+        other.manageJaEnBoundaries == manageJaEnBoundaries &&
+        other.normalizeDashes == normalizeDashes &&
+        other.normalizeBullets == normalizeBullets &&
+        other.linebreakRules == linebreakRules &&
+        other.normalizeEndPunctuation == normalizeEndPunctuation;
+  }
+
+  @override
+  int get hashCode {
+    return Object.hash(
+      normalizeAsciiWidth,
+      unifyJaPunct,
+      unifyQuotes,
+      trimSpaces,
+      collapseSpaces,
+      manageJaEnBoundaries,
+      normalizeDashes,
+      normalizeBullets,
+      linebreakRules,
+      normalizeEndPunctuation,
+    );
+  }
+
+  @override
+  String toString() {
+    return 'TextNormalizeOptions('
+        'normalizeAsciiWidth: $normalizeAsciiWidth, '
+        'unifyJaPunct: $unifyJaPunct, '
+        'unifyQuotes: $unifyQuotes, '
+        'trimSpaces: $trimSpaces, '
+        'collapseSpaces: $collapseSpaces, '
+        'manageJaEnBoundaries: $manageJaEnBoundaries, '
+        'normalizeDashes: $normalizeDashes, '
+        'normalizeBullets: $normalizeBullets, '
+        'linebreakRules: $linebreakRules, '
+        'normalizeEndPunctuation: $normalizeEndPunctuation'
+        ')';
+  }
+}

--- a/lib/services/text_normalizer.dart
+++ b/lib/services/text_normalizer.dart
@@ -1,0 +1,154 @@
+import 'text_normalize_options.dart';
+import 'text_rules/unicode.dart';
+import 'text_rules/spaces.dart';
+import 'text_rules/punctuation.dart';
+
+/// OCRテキスト整形サービス
+///
+/// 日本語向けルールベースでテキストを整形し、
+/// 読みやすく・後段のSRS抽出で扱いやすい形に正規化します。
+class TextNormalizer {
+  /// OCRで取得したテキストを整形
+  ///
+  /// [raw] 生のOCRテキスト
+  /// [options] 整形オプション（nullの場合はデフォルト設定）
+  ///
+  /// 戻り値: 整形されたテキスト
+  static String normalizeOcrText(String raw, {TextNormalizeOptions? options}) {
+    final opts = options ?? TextNormalizeOptions.defaultOptions;
+    String result = raw;
+
+    // ルール適用順序（重要：順序依存）
+
+    // ① Unicode正規化 NFKC（互換分解→結合）
+    result = UnicodeNormalizer.normalizeUnicode(result);
+
+    // ② 不可視/制御文字の除去
+    result = InvisibleCharRemover.removeInvisibleChars(result);
+
+    // ③ 全角/半角の統一
+    if (opts.normalizeAsciiWidth) {
+      result = WidthNormalizer.normalizeAsciiWidth(result);
+    }
+
+    if (opts.unifyJaPunct) {
+      result = WidthNormalizer.unifyJapanesePunctuation(result);
+    }
+
+    // ④ スペース整形
+    if (opts.trimSpaces) {
+      result = SpaceNormalizer.trimSpaces(result);
+    }
+
+    if (opts.collapseSpaces) {
+      result = SpaceNormalizer.collapseSpaces(result);
+    }
+
+    if (opts.manageJaEnBoundaries) {
+      result = SpaceNormalizer.manageJaEnBoundaries(result);
+    }
+
+    // ⑤ 改行整形
+    if (opts.linebreakRules) {
+      result = LinebreakNormalizer.normalizeLinebreaks(result);
+    }
+
+    // ⑥ ダッシュ/長音/中黒の正規化
+    if (opts.normalizeDashes) {
+      result = DashNormalizer.normalizeDashes(result);
+    }
+
+    if (opts.normalizeBullets) {
+      result = BulletNormalizer.normalizeBullets(result);
+    }
+
+    // ⑦ 引用符の統一
+    if (opts.unifyQuotes) {
+      result = QuoteNormalizer.unifyQuotes(result);
+    }
+
+    // ⑧ OCR誤認の軽微補正（安全側）
+    // 一 と ー の誤混同は置換しない（誤補正のほうが痛い）
+    // O/0、l/1/I は置換しない（将来のAIリライトへ委譲）
+
+    // ⑨ 末尾の不要な句読点の連続を1つに
+    if (opts.normalizeEndPunctuation) {
+      result = PunctuationNormalizer.normalizeEndPunctuation(result);
+    }
+
+    return result;
+  }
+
+  /// 簡易整形（基本的な整形のみ）
+  ///
+  /// Unicode正規化、不可視文字除去、スペース整形のみを適用
+  static String normalizeMinimal(String raw) {
+    return normalizeOcrText(raw, options: TextNormalizeOptions.minimalOptions);
+  }
+
+  /// 整形前後の比較情報を取得
+  ///
+  /// [raw] 生のOCRテキスト
+  /// [options] 整形オプション
+  ///
+  /// 戻り値: 整形結果とメタ情報
+  static TextNormalizeResult normalizeWithInfo(
+    String raw, {
+    TextNormalizeOptions? options,
+  }) {
+    final normalized = normalizeOcrText(raw, options: options);
+
+    return TextNormalizeResult(
+      raw: raw,
+      normalized: normalized,
+      changesCount: _countChanges(raw, normalized),
+      options: options ?? TextNormalizeOptions.defaultOptions,
+    );
+  }
+
+  /// 変更箇所数をカウント（簡易）
+  static int _countChanges(String raw, String normalized) {
+    if (raw == normalized) return 0;
+
+    // 簡易的な変更カウント（文字数差の絶対値）
+    return (raw.length - normalized.length).abs();
+  }
+}
+
+/// 整形結果とメタ情報
+class TextNormalizeResult {
+  /// 生のOCRテキスト
+  final String raw;
+
+  /// 整形されたテキスト
+  final String normalized;
+
+  /// 変更箇所数（概算）
+  final int changesCount;
+
+  /// 使用されたオプション
+  final TextNormalizeOptions options;
+
+  const TextNormalizeResult({
+    required this.raw,
+    required this.normalized,
+    required this.changesCount,
+    required this.options,
+  });
+
+  /// 整形が適用されたかどうか
+  bool get hasChanges => raw != normalized;
+
+  /// 整形前後の文字数差
+  int get lengthDifference => normalized.length - raw.length;
+
+  @override
+  String toString() {
+    return 'TextNormalizeResult('
+        'raw: ${raw.length} chars, '
+        'normalized: ${normalized.length} chars, '
+        'changes: $changesCount, '
+        'hasChanges: $hasChanges'
+        ')';
+  }
+}

--- a/lib/services/text_rules/punctuation.dart
+++ b/lib/services/text_rules/punctuation.dart
@@ -1,0 +1,108 @@
+/// ダッシュ・長音正規化ルール
+class DashNormalizer {
+  /// ダッシュ・長音を正規化
+  /// 日本語語中は ー、英語/数式は - に統一
+  static String normalizeDashes(String text) {
+    String result = text;
+
+    // 行ごとに処理
+    List<String> lines = result.split('\n');
+    List<String> processedLines = [];
+
+    for (String line in lines) {
+      String processedLine = line;
+
+      // 日本語が含まれている行は長音に統一
+      if (_containsJapanese(processedLine)) {
+        processedLine = processedLine.replaceAll('—', 'ー'); // em dash
+        processedLine = processedLine.replaceAll('–', 'ー'); // en dash
+        processedLine = processedLine.replaceAll(
+          'ｰ',
+          'ー',
+        ); // half-width katakana
+      } else {
+        // 英語行はハイフンに統一
+        processedLine = processedLine.replaceAll('—', '-'); // em dash
+        processedLine = processedLine.replaceAll('–', '-'); // en dash
+        processedLine = processedLine.replaceAll(
+          'ｰ',
+          '-',
+        ); // half-width katakana
+      }
+
+      processedLines.add(processedLine);
+    }
+
+    return processedLines.join('\n');
+  }
+
+  /// 日本語文字が含まれているかチェック
+  static bool _containsJapanese(String text) {
+    return RegExp(r'[\u3040-\u309F\u30A0-\u30FF\u4E00-\u9FAF]').hasMatch(text);
+  }
+}
+
+/// 中黒正規化ルール
+class BulletNormalizer {
+  /// 中黒を統一（･ • → ・）
+  static String normalizeBullets(String text) {
+    String result = text;
+
+    result = result.replaceAll('･', '・'); // half-width katakana middle dot
+    result = result.replaceAll('•', '・'); // bullet
+
+    return result;
+  }
+}
+
+/// 引用符統一ルール
+class QuoteNormalizer {
+  /// 引用符を統一
+  /// 日本語行は「 」、英語行は " を維持
+  static String unifyQuotes(String text) {
+    String result = text;
+
+    // 行ごとに処理
+    List<String> lines = result.split('\n');
+    List<String> processedLines = [];
+
+    for (String line in lines) {
+      String processedLine = line;
+
+      // 日本語が含まれている行は「 」に統一
+      if (_containsJapanese(processedLine)) {
+        // 最初の " を「に、最後の " を」に変換
+        processedLine = processedLine.replaceFirst('"', '「');
+        processedLine = processedLine.replaceAll('"', '」');
+      }
+      // 英語行は " を維持（変更なし）
+
+      processedLines.add(processedLine);
+    }
+
+    return processedLines.join('\n');
+  }
+
+  /// 日本語文字が含まれているかチェック
+  static bool _containsJapanese(String text) {
+    return RegExp(
+      r'[\u3040-\u309F\u3030A0-\u30FF\u4E00-\u9FAF]',
+    ).hasMatch(text);
+  }
+}
+
+/// 句読点正規化ルール
+class PunctuationNormalizer {
+  /// 末尾の句読点連続を1つに正規化（。。 → 。）
+  static String normalizeEndPunctuation(String text) {
+    String result = text;
+    
+    // 文末の句読点連続を1つに（行末のみ）
+    result = result.replaceAll(RegExp(r'。{2,}(?=\s*$)'), '。');
+    result = result.replaceAll(RegExp(r'、{2,}(?=\s*$)'), '、');
+    result = result.replaceAll(RegExp(r'！{2,}(?=\s*$)'), '！');
+    result = result.replaceAll(RegExp(r'？{2,}(?=\s*$)'), '？');
+    
+    return result;
+  }
+}

--- a/lib/services/text_rules/spaces.dart
+++ b/lib/services/text_rules/spaces.dart
@@ -1,0 +1,73 @@
+/// スペース整形ルール
+class SpaceNormalizer {
+  /// 行頭・行末の空白を削除
+  static String trimSpaces(String text) {
+    List<String> lines = text.split('\n');
+    return lines.map((line) => line.trim()).join('\n');
+  }
+
+  /// 連続スペースを1個に圧縮
+  static String collapseSpaces(String text) {
+    return text.replaceAll(RegExp(r' {2,}'), ' ');
+  }
+
+  /// 和欧境界にスペースを挿入
+  /// 日本語と英数字の境界に1スペースを挿入
+  static String manageJaEnBoundaries(String text) {
+    String result = text;
+
+    // 日本語文字（ひらがな、カタカナ、漢字）と英数字の境界
+    result = result.replaceAll(
+      RegExp(r'([\u3040-\u309F\u30A0-\u30FF\u4E00-\u9FAF])([A-Za-z0-9])'),
+      r'$1 $2',
+    );
+    result = result.replaceAll(
+      RegExp(r'([A-Za-z0-9])([\u3040-\u309F\u30A0-\u30FF\u4E00-\u9FAF])'),
+      r'$1 $2',
+    );
+
+    // 例外パターン（iPhone13等の典型パターンはスキップ）
+    result = _skipTypicalPatterns(result);
+
+    return result;
+  }
+
+  /// 典型的なパターンをスキップ（誤置換を避ける）
+  static String _skipTypicalPatterns(String text) {
+    String result = text;
+    
+    // iPhone13, iPad12 等のパターンを元に戻す
+    result = result.replaceAllMapped(RegExp(r'iPhone (\d+)'), (match) => 'iPhone${match.group(1)}');
+    result = result.replaceAllMapped(RegExp(r'iPad (\d+)'), (match) => 'iPad${match.group(1)}');
+    result = result.replaceAllMapped(RegExp(r'Mac (\d+)'), (match) => 'Mac${match.group(1)}');
+    result = result.replaceAllMapped(RegExp(r'Windows (\d+)'), (match) => 'Windows${match.group(1)}');
+    
+    // 年号パターンを元に戻す
+    result = result.replaceAllMapped(RegExp(r'(\d{4}) 年'), (match) => '${match.group(1)}年');
+    result = result.replaceAllMapped(RegExp(r'(\d{1,2}) 月'), (match) => '${match.group(1)}月');
+    result = result.replaceAllMapped(RegExp(r'(\d{1,2}) 日'), (match) => '${match.group(1)}日');
+    
+    return result;
+  }
+}
+
+/// 改行整形ルール
+class LinebreakNormalizer {
+  /// 改行を正規化
+  /// - 3連以上の改行を2つまでに圧縮
+  /// - 行末の「。」が無い場合でも段落改行は保持
+  static String normalizeLinebreaks(String text) {
+    String result = text;
+
+    // 3連以上の改行を2つまでに圧縮
+    result = result.replaceAll(RegExp(r'\n{3,}'), '\n\n');
+
+    // 行末の空白を削除
+    result = result.replaceAll(RegExp(r' +\n'), '\n');
+
+    // 空行の前後の余分な空白を削除
+    result = result.replaceAll(RegExp(r'\n +\n'), '\n\n');
+
+    return result;
+  }
+}

--- a/lib/services/text_rules/unicode.dart
+++ b/lib/services/text_rules/unicode.dart
@@ -1,0 +1,118 @@
+/// Unicode正規化ルール
+class UnicodeNormalizer {
+  /// Unicode正規化（NFKC）を適用
+  /// 互換分解→結合の順序で正規化
+  static String normalizeUnicode(String text) {
+    // DartのString.normalize()は利用できないため、
+    // 基本的な正規化のみ実装
+    // 実際のNFKC正規化は外部ライブラリが必要
+    return text;
+  }
+}
+
+/// 不可視・制御文字除去ルール
+class InvisibleCharRemover {
+  /// 不可視文字・制御文字を除去
+  /// - Zero Width Space (\u200B)
+  /// - BOM (\uFEFF)
+  /// - 異常なタブ連打
+  /// - その他の制御文字
+  static String removeInvisibleChars(String text) {
+    // Zero Width Space と BOM を除去
+    String result = text.replaceAll('\u200B', ''); // Zero Width Space
+    result = result.replaceAll('\uFEFF', ''); // BOM
+
+    // 制御文字を除去（改行・タブ・スペース以外）
+    result = result.replaceAll(RegExp(r'[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]'), '');
+
+    // 異常なタブ連打を単一タブに
+    result = result.replaceAll(RegExp(r'\t{2,}'), '\t');
+
+    return result;
+  }
+}
+
+/// 全角・半角統一ルール
+class WidthNormalizer {
+  /// 英数字・記号を半角に統一
+  /// 日本語はそのまま保持
+  static String normalizeAsciiWidth(String text) {
+    String result = text;
+
+    // 全角英数字を半角に変換
+    result = result.replaceAllMapped(RegExp(r'[０-９]'), (match) {
+      return String.fromCharCode(match.group(0)!.codeUnitAt(0) - 0xFF10 + 0x30);
+    });
+
+    result = result.replaceAllMapped(RegExp(r'[Ａ-Ｚ]'), (match) {
+      return String.fromCharCode(match.group(0)!.codeUnitAt(0) - 0xFF21 + 0x41);
+    });
+
+    result = result.replaceAllMapped(RegExp(r'[ａ-ｚ]'), (match) {
+      return String.fromCharCode(match.group(0)!.codeUnitAt(0) - 0xFF41 + 0x61);
+    });
+
+    // 全角記号を半角に変換
+    result = result.replaceAll('（', '(');
+    result = result.replaceAll('）', ')');
+    result = result.replaceAll('［', '[');
+    result = result.replaceAll('］', ']');
+    result = result.replaceAll('｛', '{');
+    result = result.replaceAll('｝', '}');
+    result = result.replaceAll('「', '"');
+    result = result.replaceAll('」', '"');
+    result = result.replaceAll('『', "'");
+    result = result.replaceAll('』', "'");
+    result = result.replaceAll('＋', '+');
+    result = result.replaceAll('－', '-');
+    result = result.replaceAll('＊', '*');
+    result = result.replaceAll('／', '/');
+    result = result.replaceAll('＝', '=');
+    result = result.replaceAll('％', '%');
+    result = result.replaceAll('＃', '#');
+    result = result.replaceAll('＠', '@');
+    result = result.replaceAll('！', '!');
+    result = result.replaceAll('？', '?');
+    result = result.replaceAll('：', ':');
+    result = result.replaceAll('；', ';');
+    result = result.replaceAll('，', ',');
+    result = result.replaceAll('．', '.');
+
+    return result;
+  }
+
+  /// 日本語句読点の統一（, . → 、 。）
+  /// 日本語行のみに適用
+  static String unifyJapanesePunctuation(String text) {
+    String result = text;
+
+    // 行ごとに処理
+    List<String> lines = result.split('\n');
+    List<String> processedLines = [];
+
+    for (String line in lines) {
+      String processedLine = line;
+
+      // 日本語が含まれている行のみ処理
+      if (_containsJapanese(processedLine)) {
+        // 文末の . を 。 に変換
+        processedLine = processedLine.replaceAll(RegExp(r'\.(?=\s*$)'), '。');
+
+        // 文中の , を 、 に変換（ただし英語の数字表記は除外）
+        processedLine = processedLine.replaceAll(
+          RegExp(r',(?=\s*[^0-9])'),
+          '、',
+        );
+      }
+
+      processedLines.add(processedLine);
+    }
+
+    return processedLines.join('\n');
+  }
+
+  /// 日本語文字が含まれているかチェック
+  static bool _containsJapanese(String text) {
+    return RegExp(r'[\u3040-\u309F\u30A0-\u30FF\u4E00-\u9FAF]').hasMatch(text);
+  }
+}

--- a/test/pages/home_page_gallery_ocr_test.dart
+++ b/test/pages/home_page_gallery_ocr_test.dart
@@ -91,7 +91,6 @@ void main() {
 
       // 結果ダイアログが表示されることを確認
       expect(find.text('OCR結果'), findsOneWidget);
-      expect(find.text('抽出されたテキスト:'), findsOneWidget);
       expect(find.textContaining('ギャラリーOCR'), findsOneWidget);
 
       // ダイアログを閉じる

--- a/test/pages/home_page_normalized_view_test.dart
+++ b/test/pages/home_page_normalized_view_test.dart
@@ -1,0 +1,222 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/provider.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:image_picker/image_picker.dart';
+
+import 'package:snap_jp_learn_app/pages/home_page.dart';
+import 'package:snap_jp_learn_app/services/ocr_service.dart';
+import 'package:snap_jp_learn_app/features/settings/services/settings_service.dart';
+
+/// OCRテキスト整形機能のモックサービス
+class MockOcrServiceWithNormalization implements OcrService {
+  @override
+  Future<String> extractTextFromXFile(XFile image) async {
+    await Future.delayed(const Duration(milliseconds: 300));
+    return 'Ｔｅｓｔ１２３,今日は晴れ.'; // 整形が必要なテキスト
+  }
+
+  @override
+  Future<String> extractTextFromImage({
+    ImageSource source = ImageSource.camera,
+  }) async {
+    await Future.delayed(const Duration(milliseconds: 300));
+    return 'Ｔｅｓｔ１２３,今日は晴れ.'; // 整形が必要なテキスト
+  }
+
+  @override
+  void dispose() {
+    // Mock service has no resources to dispose
+  }
+}
+
+void main() {
+  group('HomePage Normalized View Tests', () {
+    late MockOcrServiceWithNormalization mockOcrService;
+    late SettingsService settingsService;
+
+    setUp(() async {
+      // SharedPreferencesのモック化
+      SharedPreferences.setMockInitialValues({});
+
+      mockOcrService = MockOcrServiceWithNormalization();
+      settingsService = SettingsService();
+      await settingsService.initialize();
+    });
+
+    testWidgets('OCR結果ダイアログにRaw/Normalized切替が表示される', (
+      WidgetTester tester,
+    ) async {
+      await tester.pumpWidget(
+        ChangeNotifierProvider<SettingsService>.value(
+          value: settingsService,
+          child: MaterialApp(home: HomePage(ocrService: mockOcrService)),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // スクロールしてテストボタンを表示
+      await tester.scrollUntilVisible(
+        find.text('テスト'),
+        500.0,
+        scrollable: find.byType(Scrollable).first,
+      );
+
+      // テストボタンをタップ
+      await tester.tap(find.text('テスト'), warnIfMissed: false);
+      await tester.pump();
+
+      // OCR処理完了まで待機
+      await tester.pump(const Duration(milliseconds: 400));
+
+      // OCR結果ダイアログが表示されることを確認
+      expect(find.text('OCR結果'), findsOneWidget);
+
+      // Raw/Normalized切替タブが表示されることを確認
+      expect(find.text('Raw'), findsOneWidget);
+      expect(find.text('Normalized'), findsOneWidget);
+
+      // 整形されたテキストが表示されることを確認
+      expect(find.text('整形されたテキスト:'), findsOneWidget);
+      expect(find.textContaining('Test123'), findsOneWidget);
+      expect(find.textContaining('今日は晴れ。'), findsOneWidget);
+    });
+
+    testWidgets('Raw/Normalized切替が動作する', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        ChangeNotifierProvider<SettingsService>.value(
+          value: settingsService,
+          child: MaterialApp(home: HomePage(ocrService: mockOcrService)),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // スクロールしてテストボタンを表示
+      await tester.scrollUntilVisible(
+        find.text('テスト'),
+        500.0,
+        scrollable: find.byType(Scrollable).first,
+      );
+
+      // テストボタンをタップ
+      await tester.tap(find.text('テスト'), warnIfMissed: false);
+      await tester.pump();
+
+      // OCR処理完了まで待機
+      await tester.pump(const Duration(milliseconds: 400));
+
+      // 初期状態でNormalizedが表示されていることを確認
+      expect(find.text('整形されたテキスト:'), findsOneWidget);
+      expect(find.textContaining('Test123'), findsOneWidget);
+
+      // Rawタブをタップ
+      await tester.tap(find.text('Raw'));
+      await tester.pump();
+
+      // Raw表示に切り替わることを確認
+      expect(find.text('生のテキスト:'), findsOneWidget);
+      expect(find.textContaining('Ｔｅｓｔ１２３'), findsOneWidget);
+      expect(find.textContaining('今日は晴れ.'), findsOneWidget);
+
+      // Normalizedタブをタップ
+      await tester.tap(find.text('Normalized'));
+      await tester.pump();
+
+      // Normalized表示に戻ることを確認
+      expect(find.text('整形されたテキスト:'), findsOneWidget);
+      expect(find.textContaining('Test123'), findsOneWidget);
+    });
+
+    testWidgets('コピーボタンが動作する', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        ChangeNotifierProvider<SettingsService>.value(
+          value: settingsService,
+          child: MaterialApp(home: HomePage(ocrService: mockOcrService)),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // スクロールしてテストボタンを表示
+      await tester.scrollUntilVisible(
+        find.text('テスト'),
+        500.0,
+        scrollable: find.byType(Scrollable).first,
+      );
+
+      // テストボタンをタップ
+      await tester.tap(find.text('テスト'), warnIfMissed: false);
+      await tester.pump();
+
+      // OCR処理完了まで待機
+      await tester.pump(const Duration(milliseconds: 400));
+
+      // コピーボタンが表示されることを確認
+      expect(find.text('コピー'), findsOneWidget);
+
+      // コピーボタンをタップ
+      await tester.tap(find.text('コピー'));
+      await tester.pump();
+
+      // コピー完了のSnackBarが表示されることを確認
+      expect(find.textContaining('整形されたテキストをコピーしました'), findsOneWidget);
+    });
+
+    testWidgets('整形情報が表示される', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        ChangeNotifierProvider<SettingsService>.value(
+          value: settingsService,
+          child: MaterialApp(home: HomePage(ocrService: mockOcrService)),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // スクロールしてテストボタンを表示
+      await tester.scrollUntilVisible(
+        find.text('テスト'),
+        500.0,
+        scrollable: find.byType(Scrollable).first,
+      );
+
+      // テストボタンをタップ
+      await tester.tap(find.text('テスト'), warnIfMissed: false);
+      await tester.pump();
+
+      // OCR処理完了まで待機
+      await tester.pump(const Duration(milliseconds: 400));
+
+      // 整形情報が表示されることを確認
+      expect(find.text('テキストが整形されました'), findsOneWidget);
+    });
+
+    testWidgets('テキストが選択可能である', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        ChangeNotifierProvider<SettingsService>.value(
+          value: settingsService,
+          child: MaterialApp(home: HomePage(ocrService: mockOcrService)),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // スクロールしてテストボタンを表示
+      await tester.scrollUntilVisible(
+        find.text('テスト'),
+        500.0,
+        scrollable: find.byType(Scrollable).first,
+      );
+
+      // テストボタンをタップ
+      await tester.tap(find.text('テスト'), warnIfMissed: false);
+      await tester.pump();
+
+      // OCR処理完了まで待機
+      await tester.pump(const Duration(milliseconds: 400));
+
+      // SelectableTextが使用されていることを確認
+      expect(find.byType(SelectableText), findsOneWidget);
+    });
+
+    tearDown(() {
+      mockOcrService.dispose();
+    });
+  });
+}

--- a/test/services/text_normalizer_test.dart
+++ b/test/services/text_normalizer_test.dart
@@ -1,0 +1,319 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:snap_jp_learn_app/services/text_normalizer.dart';
+import 'package:snap_jp_learn_app/services/text_normalize_options.dart';
+
+void main() {
+  group('TextNormalizer', () {
+    group('基本機能', () {
+      test('空文字列の処理', () {
+        expect(TextNormalizer.normalizeOcrText(''), equals(''));
+      });
+
+      test('変更なしのテキスト', () {
+        const text = 'Hello World';
+        expect(TextNormalizer.normalizeOcrText(text), equals(text));
+      });
+
+      test('簡易整形の動作確認', () {
+        const text = 'Ｔｅｓｔ１２３';
+        const expected = 'Test123';
+        expect(TextNormalizer.normalizeMinimal(text), equals(expected));
+      });
+    });
+
+    group('Unicode正規化', () {
+      test('NFKC正規化の動作', () {
+        // 互換文字の正規化例
+        const text = '㌀'; // 合字
+        final result = TextNormalizer.normalizeOcrText(text);
+        expect(result, isNotEmpty);
+        // 現在は基本的な実装のため、文字数は変わらない
+        expect(result.length, equals(1));
+      });
+    });
+
+    group('不可視文字除去', () {
+      test('Zero Width Space除去', () {
+        const text = 'A\u200BBC';
+        const expected = 'ABC';
+        expect(TextNormalizer.normalizeOcrText(text), equals(expected));
+      });
+
+      test('BOM除去', () {
+        const text = '\uFEFFHello';
+        const expected = 'Hello';
+        expect(TextNormalizer.normalizeOcrText(text), equals(expected));
+      });
+
+      test('制御文字除去', () {
+        const text = 'A\x00B\x01C';
+        const expected = 'ABC';
+        expect(TextNormalizer.normalizeOcrText(text), equals(expected));
+      });
+
+      test('異常タブ連打の正規化', () {
+        const text = 'A\t\t\tB';
+        const expected = 'A\tB';
+        expect(TextNormalizer.normalizeOcrText(text), equals(expected));
+      });
+    });
+
+    group('全角・半角統一', () {
+      test('全角数字の半角化', () {
+        const text = '１２３４５';
+        const expected = '12345';
+        expect(TextNormalizer.normalizeOcrText(text), equals(expected));
+      });
+
+      test('全角英字の半角化', () {
+        const text = 'ＡＢＣＤＥＦ';
+        const expected = 'ABCDEF';
+        expect(TextNormalizer.normalizeOcrText(text), equals(expected));
+      });
+
+      test('全角小文字の半角化', () {
+        const text = 'ａｂｃｄｅｆ';
+        const expected = 'abcdef';
+        expect(TextNormalizer.normalizeOcrText(text), equals(expected));
+      });
+
+      test('全角記号の半角化', () {
+        const text = '（），．！？';
+        const expected = '(),.!?';
+        expect(TextNormalizer.normalizeOcrText(text), equals(expected));
+      });
+
+      test('日本語句読点の統一', () {
+        const text = '今日は,晴れ.';
+        const expected = '今日は、晴れ。';
+        expect(TextNormalizer.normalizeOcrText(text), equals(expected));
+      });
+
+      test('英語行の句読点は変更しない', () {
+        const text = 'Hello, world.';
+        const expected = 'Hello, world.';
+        expect(TextNormalizer.normalizeOcrText(text), equals(expected));
+      });
+    });
+
+    group('スペース整形', () {
+      test('行頭・行末の空白削除', () {
+        const text = '  Hello  \n  World  ';
+        const expected = 'Hello\nWorld';
+        expect(TextNormalizer.normalizeOcrText(text), equals(expected));
+      });
+
+      test('連続スペースの圧縮', () {
+        const text = 'A    B   C';
+        const expected = 'A B C';
+        expect(TextNormalizer.normalizeOcrText(text), equals(expected));
+      });
+
+      test('和欧境界のスペース挿入', () {
+        const text = '東京2025EXPO';
+        const expected = '東京 2025 EXPO';
+        expect(TextNormalizer.normalizeOcrText(text), equals(expected));
+      });
+
+      test('iPhone13パターンのスキップ', () {
+        const text = 'iPhone13';
+        const expected = 'iPhone13'; // 変更されない
+        expect(TextNormalizer.normalizeOcrText(text), equals(expected));
+      });
+
+      test('年号パターンのスキップ', () {
+        const text = '2025年';
+        const expected = '2025年'; // 変更されない
+        expect(TextNormalizer.normalizeOcrText(text), equals(expected));
+      });
+    });
+
+    group('改行整形', () {
+      test('3連以上の改行を2つまでに圧縮', () {
+        const text = 'A\n\n\n\nB';
+        const expected = 'A\n\nB';
+        expect(TextNormalizer.normalizeOcrText(text), equals(expected));
+      });
+
+      test('行末の空白削除', () {
+        const text = 'Hello   \nWorld';
+        const expected = 'Hello\nWorld';
+        expect(TextNormalizer.normalizeOcrText(text), equals(expected));
+      });
+    });
+
+    group('ダッシュ・中黒正規化', () {
+      test('日本語行のダッシュを長音に', () {
+        const text = '明治—大正—昭和';
+        const expected = '明治ー大正ー昭和';
+        expect(TextNormalizer.normalizeOcrText(text), equals(expected));
+      });
+
+      test('英語行のダッシュをハイフンに', () {
+        const text = 'A—B—C';
+        const expected = 'A-B-C';
+        expect(TextNormalizer.normalizeOcrText(text), equals(expected));
+      });
+
+      test('中黒の統一', () {
+        const text = 'A･B•C';
+        const expected = 'A・B・C';
+        expect(TextNormalizer.normalizeOcrText(text), equals(expected));
+      });
+    });
+
+    group('引用符統一', () {
+      test('日本語行の引用符を「」に', () {
+        const text = '"太郎"';
+        const expected = '「太郎」';
+        expect(TextNormalizer.normalizeOcrText(text), equals(expected));
+      });
+
+      test('英語行の引用符は変更しない', () {
+        const text = '"Hello"';
+        const expected = '"Hello"';
+        expect(TextNormalizer.normalizeOcrText(text), equals(expected));
+      });
+    });
+
+    group('句読点正規化', () {
+      test('末尾句読点の連続を1つに', () {
+        const text = 'こんにちは。。';
+        const expected = 'こんにちは。';
+        expect(TextNormalizer.normalizeOcrText(text), equals(expected));
+      });
+
+      test('文中の句読点連続は変更しない', () {
+        const text = 'A。。B';
+        const expected = 'A。。B'; // 文中は変更されない
+        expect(TextNormalizer.normalizeOcrText(text), equals(expected));
+      });
+    });
+
+    group('複合ケース', () {
+      test('複数のルールが組み合わさる場合', () {
+        const text = 'Ｔｅｓｔ１２３,今日は晴れ.';
+        const expected = 'Test123、今日は晴れ。';
+        expect(TextNormalizer.normalizeOcrText(text), equals(expected));
+      });
+
+      test('和欧混在テキスト', () {
+        const text = '東京2025EXPOでiPhone13を展示';
+        const expected = '東京 2025 EXPOでiPhone13を展示';
+        expect(TextNormalizer.normalizeOcrText(text), equals(expected));
+      });
+
+      test('改行とスペースの複合', () {
+        const text = '  A    \n\n\n\n  B    ';
+        const expected = 'A\n\nB';
+        expect(TextNormalizer.normalizeOcrText(text), equals(expected));
+      });
+    });
+
+    group('オプション制御', () {
+      test('全角半角化を無効化', () {
+        const text = '１２３';
+        const options = TextNormalizeOptions(normalizeAsciiWidth: false);
+        const expected = '１２３'; // 変更されない
+        expect(
+          TextNormalizer.normalizeOcrText(text, options: options),
+          equals(expected),
+        );
+      });
+
+      test('句読点統一を無効化', () {
+        const text = '今日は,晴れ.';
+        const options = TextNormalizeOptions(unifyJaPunct: false);
+        const expected = '今日は,晴れ.'; // 変更されない
+        expect(
+          TextNormalizer.normalizeOcrText(text, options: options),
+          equals(expected),
+        );
+      });
+
+      test('カスタムオプションの組み合わせ', () {
+        const text = '１２３,今日は晴れ.';
+        const options = TextNormalizeOptions(
+          normalizeAsciiWidth: true,
+          unifyJaPunct: false,
+        );
+        const expected = '123,今日は晴れ.'; // 数字のみ半角化
+        expect(
+          TextNormalizer.normalizeOcrText(text, options: options),
+          equals(expected),
+        );
+      });
+    });
+
+    group('TextNormalizeResult', () {
+      test('整形結果の情報取得', () {
+        const text = '１２３';
+        final result = TextNormalizer.normalizeWithInfo(text);
+        
+        expect(result.raw, equals(text));
+        expect(result.normalized, equals('123'));
+        expect(result.hasChanges, isTrue);
+        expect(result.changesCount, greaterThanOrEqualTo(0)); // 変更カウントは概算
+        expect(result.lengthDifference, lessThan(0)); // 文字数が減る
+      });
+
+      test('変更なしの場合', () {
+        const text = 'Hello World';
+        final result = TextNormalizer.normalizeWithInfo(text);
+
+        expect(result.raw, equals(text));
+        expect(result.normalized, equals(text));
+        expect(result.hasChanges, isFalse);
+        expect(result.changesCount, equals(0));
+        expect(result.lengthDifference, equals(0));
+      });
+    });
+
+    group('パフォーマンス', () {
+      test('長文の処理時間', () {
+        // 3000文字程度のテキスト
+        final longText = '１２３４５６７８９０' * 300;
+
+        final stopwatch = Stopwatch()..start();
+        final result = TextNormalizer.normalizeOcrText(longText);
+        stopwatch.stop();
+
+        expect(result, isNotEmpty);
+        expect(stopwatch.elapsedMilliseconds, lessThan(100)); // 100ms以下
+      });
+    });
+  });
+
+  group('TextNormalizeOptions', () {
+    test('デフォルトオプション', () {
+      const options = TextNormalizeOptions.defaultOptions;
+      expect(options.normalizeAsciiWidth, isTrue);
+      expect(options.unifyJaPunct, isTrue);
+      expect(options.unifyQuotes, isTrue);
+    });
+
+    test('最小限オプション', () {
+      const options = TextNormalizeOptions.minimalOptions;
+      expect(options.normalizeAsciiWidth, isTrue);
+      expect(options.unifyJaPunct, isFalse);
+      expect(options.unifyQuotes, isFalse);
+    });
+
+    test('copyWith機能', () {
+      const original = TextNormalizeOptions.defaultOptions;
+      final modified = original.copyWith(unifyJaPunct: false);
+
+      expect(modified.unifyJaPunct, isFalse);
+      expect(modified.normalizeAsciiWidth, isTrue); // 他の設定は維持
+    });
+
+    test('等価性', () {
+      const options1 = TextNormalizeOptions();
+      const options2 = TextNormalizeOptions();
+      const options3 = TextNormalizeOptions(unifyJaPunct: false);
+
+      expect(options1, equals(options2));
+      expect(options1, isNot(equals(options3)));
+    });
+  });
+}


### PR DESCRIPTION
- Add TextNormalizeOptions for configurable normalization rules
- Implement rule-based text normalization:
  * Unicode normalization (NFKC placeholder)
  * Remove invisible/control characters
  * Normalize full-width/half-width characters
  * Unify Japanese punctuation
  * Normalize spaces (trim, collapse, manage JA/EN boundaries)
  * Normalize linebreaks (compress excessive newlines)
  * Normalize dashes, bullets, quotes
  * Handle end punctuation
- Add Raw/Normalized toggle in OCR result dialog
- Add clipboard copy function for normalized text
- Add comprehensive unit tests for text normalization
- Add widget tests for normalized view
- Update README with normalization policy and future plans

Note: Some tests are failing due to regex patterns, will be fixed in next commit