### PR TITLE
feat(PR-10): implement learning statistics with SRS integration

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -6,14 +6,41 @@ import 'pages/feed_page.dart';
 import 'pages/learn_page.dart';
 import 'pages/stats_page.dart';
 import 'pages/settings_page.dart';
+import 'services/stats_service.dart';
+import 'repositories/srs_repository.dart';
+import 'repositories/srs_repository_impl.dart';
+import 'repositories/post_repository.dart';
+import 'repositories/post_repository_impl.dart';
+import 'data/local/srs_local_data_source.dart';
+import 'data/local/post_local_data_source.dart';
 
 class SnapJpLearnApp extends StatelessWidget {
   const SnapJpLearnApp({super.key});
 
   @override
   Widget build(BuildContext context) {
-    return ChangeNotifierProvider(
-      create: (context) => SettingsService()..initialize(),
+    // データソースとリポジトリの初期化
+    final srsDataSource = SrsLocalDataSource();
+    final postDataSource = PostLocalDataSource();
+    final srsRepository = SrsRepositoryImpl(srsDataSource);
+    final postRepository = PostRepositoryImpl(postDataSource);
+    final statsService = StatsService(
+      srsRepository: srsRepository,
+      postRepository: postRepository,
+    );
+
+    // SrsRepositoryにStatsServiceを設定
+    srsRepository.setStatsService(statsService);
+
+    return MultiProvider(
+      providers: [
+        ChangeNotifierProvider(
+          create: (context) => SettingsService()..initialize(),
+        ),
+        Provider<SrsRepository>.value(value: srsRepository),
+        Provider<PostRepository>.value(value: postRepository),
+        Provider<StatsService>.value(value: statsService),
+      ],
       child: MaterialApp(
         title: 'Snap JP Learn',
         theme: ThemeData(

--- a/lib/data/local/srs_local_data_source.dart
+++ b/lib/data/local/srs_local_data_source.dart
@@ -295,6 +295,37 @@ class SrsLocalDataSource {
     }
   }
 
+  /// 全てのカードを取得
+  Future<List<SrsCard>> getAllCards() async {
+    try {
+      await init();
+      return _cards.values.toList();
+    } catch (e) {
+      throw SrsLocalDataSourceException('Failed to get all cards: $e');
+    }
+  }
+
+  /// Dueカードを取得（制限なし）
+  Future<List<SrsCard>> getAllDueCards() async {
+    try {
+      await init();
+      final now = DateTime.now();
+      return _cards.values.where((card) => card.due.isBefore(now)).toList();
+    } catch (e) {
+      throw SrsLocalDataSourceException('Failed to get all due cards: $e');
+    }
+  }
+
+  /// 全てのレビューログを取得
+  Future<List<ReviewLog>> getAllReviewLogs() async {
+    try {
+      await init();
+      return _logs.values.toList();
+    } catch (e) {
+      throw SrsLocalDataSourceException('Failed to get all review logs: $e');
+    }
+  }
+
   /// ボックスをクリア（全データ削除）
   Future<void> clear() async {
     try {

--- a/lib/pages/home_page.dart
+++ b/lib/pages/home_page.dart
@@ -8,6 +8,7 @@ import '../services/ocr_service.dart';
 import '../services/ocr_service_mlkit.dart';
 import '../services/camera_permission_service.dart';
 import '../services/text_normalizer.dart';
+import 'stats_page.dart';
 
 class HomePage extends StatefulWidget {
   final OcrService? ocrService; // テスト用にDI可能
@@ -265,6 +266,19 @@ class _HomePageState extends State<HomePage> {
       appBar: AppBar(
         title: const Text('Home'),
         backgroundColor: Theme.of(context).colorScheme.inversePrimary,
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.analytics_outlined),
+            onPressed: () {
+              Navigator.of(context).push(
+                MaterialPageRoute(
+                  builder: (context) => const StatsPage(),
+                ),
+              );
+            },
+            tooltip: '学習統計',
+          ),
+        ],
       ),
       body: Consumer<SettingsService>(
         builder: (context, settingsService, child) {

--- a/lib/pages/stats_page.dart
+++ b/lib/pages/stats_page.dart
@@ -1,104 +1,96 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
-import '../features/settings/services/settings_service.dart';
-import '../widgets/srs_preview_card.dart';
+import '../services/stats_service.dart';
 
-class StatsPage extends StatelessWidget {
+class StatsPage extends StatefulWidget {
   const StatsPage({super.key});
+
+  @override
+  State<StatsPage> createState() => _StatsPageState();
+}
+
+class _StatsPageState extends State<StatsPage> {
+  @override
+  void initState() {
+    super.initState();
+    // ページ表示時に統計を更新
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      context.read<StatsService>().refreshStats();
+    });
+  }
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: const Text('Stats'),
+        title: const Text('学習統計'),
         backgroundColor: Theme.of(context).colorScheme.inversePrimary,
       ),
-      body: Consumer<SettingsService>(
-        builder: (context, settingsService, child) {
-          return SingleChildScrollView(
-            child: Column(
-              children: [
-                const SizedBox(height: 32),
-                const Icon(Icons.bar_chart, size: 64),
-                const SizedBox(height: 16),
-                const Text('統計画面', style: TextStyle(fontSize: 24)),
-                const SizedBox(height: 8),
-                const Text('学習進捗と統計情報を表示', style: TextStyle(fontSize: 16)),
-                const SizedBox(height: 32),
-                if (settingsService.srsPreviewEnabled) ...[
-                  const SrsPreviewCard(),
+      body: FutureBuilder<LearningStats>(
+        future: context.read<StatsService>().getStats(),
+        builder: (context, snapshot) {
+          if (snapshot.connectionState == ConnectionState.waiting) {
+            return const Center(
+              child: CircularProgressIndicator(),
+            );
+          }
+
+          if (snapshot.hasError) {
+            return Center(
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  const Icon(
+                    Icons.error_outline,
+                    size: 64,
+                    color: Colors.red,
+                  ),
                   const SizedBox(height: 16),
+                  Text(
+                    '統計データの読み込みに失敗しました',
+                    style: Theme.of(context).textTheme.titleMedium,
+                  ),
+                  const SizedBox(height: 8),
+                  Text(
+                    snapshot.error.toString(),
+                    style: Theme.of(context).textTheme.bodySmall,
+                    textAlign: TextAlign.center,
+                  ),
+                  const SizedBox(height: 16),
+                  ElevatedButton(
+                    onPressed: () {
+                      setState(() {});
+                    },
+                    child: const Text('再試行'),
+                  ),
                 ],
-                Card(
-                  margin: const EdgeInsets.all(16),
-                  child: Padding(
-                    padding: const EdgeInsets.all(16),
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        Row(
-                          children: [
-                            const Icon(Icons.trending_up, color: Colors.blue),
-                            const SizedBox(width: 8),
-                            Text(
-                              '学習統計',
-                              style: Theme.of(context)
-                                  .textTheme
-                                  .titleMedium
-                                  ?.copyWith(fontWeight: FontWeight.bold),
-                            ),
-                          ],
-                        ),
-                        const SizedBox(height: 16),
-                        Row(
-                          mainAxisAlignment: MainAxisAlignment.spaceAround,
-                          children: [
-                            _buildStatItem(context, '今日の学習', '0', '単語'),
-                            _buildStatItem(context, '連続日数', '0', '日'),
-                            _buildStatItem(context, '総学習数', '0', '単語'),
-                          ],
-                        ),
-                      ],
-                    ),
-                  ),
-                ),
-                Card(
-                  margin: const EdgeInsets.all(16),
-                  child: Padding(
-                    padding: const EdgeInsets.all(16),
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        Row(
-                          children: [
-                            const Icon(
-                              Icons.photo_library,
-                              color: Colors.orange,
-                            ),
-                            const SizedBox(width: 8),
-                            Text(
-                              '投稿統計',
-                              style: Theme.of(context)
-                                  .textTheme
-                                  .titleMedium
-                                  ?.copyWith(fontWeight: FontWeight.bold),
-                            ),
-                          ],
-                        ),
-                        const SizedBox(height: 16),
-                        Row(
-                          mainAxisAlignment: MainAxisAlignment.spaceAround,
-                          children: [
-                            _buildStatItem(context, '今月の投稿', '0', '枚'),
-                            _buildStatItem(context, '総投稿数', '0', '枚'),
-                            _buildStatItem(context, 'いいね', '0', '個'),
-                          ],
-                        ),
-                      ],
-                    ),
-                  ),
-                ),
-              ],
+              ),
+            );
+          }
+
+          final stats = snapshot.data!;
+          return RefreshIndicator(
+            onRefresh: () async {
+              await context.read<StatsService>().refreshStats();
+              setState(() {});
+            },
+            child: SingleChildScrollView(
+              physics: const AlwaysScrollableScrollPhysics(),
+              padding: const EdgeInsets.all(16),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  _buildHeaderCard(stats),
+                  const SizedBox(height: 16),
+                  _buildReviewStatsCard(stats),
+                  const SizedBox(height: 16),
+                  _buildLearningProgressCard(stats),
+                  const SizedBox(height: 16),
+                  _buildCardStatsCard(stats),
+                  const SizedBox(height: 16),
+                  _buildLastUpdatedCard(stats),
+                ],
+              ),
             ),
           );
         },
@@ -106,39 +98,244 @@ class StatsPage extends StatelessWidget {
     );
   }
 
+  Widget _buildHeaderCard(LearningStats stats) {
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                Icon(
+                  Icons.analytics_outlined,
+                  color: Theme.of(context).colorScheme.primary,
+                ),
+                const SizedBox(width: 8),
+                Text(
+                  '学習状況サマリー',
+                  style: Theme.of(context).textTheme.titleLarge?.copyWith(
+                        fontWeight: FontWeight.bold,
+                      ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 16),
+            Row(
+              children: [
+                Expanded(
+                  child: _buildStatItem(
+                    '学習継続日数',
+                    '${stats.streakDays}日',
+                    Icons.local_fire_department,
+                    Colors.orange,
+                  ),
+                ),
+                const SizedBox(width: 16),
+                Expanded(
+                  child: _buildStatItem(
+                    '今日のレビュー',
+                    '${stats.todayReviews}回',
+                    Icons.check_circle,
+                    Colors.green,
+                  ),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildReviewStatsCard(LearningStats stats) {
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                Icon(
+                  Icons.quiz_outlined,
+                  color: Theme.of(context).colorScheme.primary,
+                ),
+                const SizedBox(width: 8),
+                Text(
+                  'レビュー統計',
+                  style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                        fontWeight: FontWeight.bold,
+                      ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 16),
+            _buildStatRow('今日', '${stats.todayReviews}回', Colors.blue),
+            _buildStatRow('今週', '${stats.weekReviews}回', Colors.purple),
+            _buildStatRow('今月', '${stats.monthReviews}回', Colors.indigo),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildLearningProgressCard(LearningStats stats) {
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                Icon(
+                  Icons.schedule_outlined,
+                  color: Theme.of(context).colorScheme.primary,
+                ),
+                const SizedBox(width: 8),
+                Text(
+                  '学習進捗',
+                  style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                        fontWeight: FontWeight.bold,
+                      ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 16),
+            _buildStatRow('今日のDue', '${stats.todayDueCount}件', Colors.orange),
+            _buildStatRow('残りDue', '${stats.remainingDueCount}件', Colors.red),
+            const SizedBox(height: 8),
+            if (stats.remainingDueCount > 0)
+              LinearProgressIndicator(
+                value: (stats.todayDueCount / stats.remainingDueCount)
+                    .clamp(0.0, 1.0),
+                backgroundColor: Colors.grey[300],
+                valueColor: AlwaysStoppedAnimation<Color>(
+                  Theme.of(context).colorScheme.primary,
+                ),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildCardStatsCard(LearningStats stats) {
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                Icon(
+                  Icons.style_outlined,
+                  color: Theme.of(context).colorScheme.primary,
+                ),
+                const SizedBox(width: 8),
+                Text(
+                  'カード統計',
+                  style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                        fontWeight: FontWeight.bold,
+                      ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 16),
+            _buildStatRow('累計カード数', '${stats.totalCards}枚', Colors.teal),
+            _buildStatRow('今週作成', '${stats.weekCreatedCards}枚', Colors.cyan),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildLastUpdatedCard(LearningStats stats) {
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Row(
+          children: [
+            Icon(
+              Icons.update_outlined,
+              color: Colors.grey[600],
+              size: 16,
+            ),
+            const SizedBox(width: 8),
+            Text(
+              '最終更新: ${_formatDateTime(stats.lastUpdated)}',
+              style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                    color: Colors.grey[600],
+                  ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
   Widget _buildStatItem(
-    BuildContext context,
-    String title,
-    String value,
-    String unit,
-  ) {
+      String label, String value, IconData icon, Color color) {
     return Column(
       children: [
-        Text(
-          title,
-          style: Theme.of(
-            context,
-          ).textTheme.bodySmall?.copyWith(color: Colors.grey[600]),
+        Icon(
+          icon,
+          color: color,
+          size: 32,
         ),
-        const SizedBox(height: 4),
-        RichText(
-          text: TextSpan(
-            children: [
-              TextSpan(
-                text: value,
-                style: Theme.of(context).textTheme.headlineSmall?.copyWith(
-                      fontWeight: FontWeight.bold,
-                      color: Theme.of(context).primaryColor,
-                    ),
+        const SizedBox(height: 8),
+        Text(
+          value,
+          style: Theme.of(context).textTheme.titleLarge?.copyWith(
+                fontWeight: FontWeight.bold,
+                color: color,
               ),
-              TextSpan(
-                text: unit,
-                style: Theme.of(context).textTheme.bodyMedium,
-              ),
-            ],
-          ),
+        ),
+        Text(
+          label,
+          style: Theme.of(context).textTheme.bodySmall,
+          textAlign: TextAlign.center,
         ),
       ],
     );
+  }
+
+  Widget _buildStatRow(String label, String value, Color color) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 4),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        children: [
+          Text(
+            label,
+            style: Theme.of(context).textTheme.bodyMedium,
+          ),
+          Text(
+            value,
+            style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                  fontWeight: FontWeight.bold,
+                  color: color,
+                ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  String _formatDateTime(DateTime dateTime) {
+    final now = DateTime.now();
+    final difference = now.difference(dateTime);
+
+    if (difference.inMinutes < 1) {
+      return 'たった今';
+    } else if (difference.inMinutes < 60) {
+      return '${difference.inMinutes}分前';
+    } else if (difference.inHours < 24) {
+      return '${difference.inHours}時間前';
+    } else {
+      return '${dateTime.month}/${dateTime.day} ${dateTime.hour.toString().padLeft(2, '0')}:${dateTime.minute.toString().padLeft(2, '0')}';
+    }
   }
 }

--- a/lib/repositories/srs_repository.dart
+++ b/lib/repositories/srs_repository.dart
@@ -115,6 +115,21 @@ abstract class SrsRepository {
     String sourceSnippet,
   );
 
+  /// 全てのカードを取得
+  ///
+  /// Returns: 全カードのリスト
+  Future<List<SrsCard>> getAllCards();
+
+  /// Dueカードを取得
+  ///
+  /// Returns: Dueカードのリスト
+  Future<List<SrsCard>> getDueCards();
+
+  /// 全てのレビューログを取得
+  ///
+  /// Returns: 全レビューログのリスト
+  Future<List<ReviewLog>> getAllReviewLogs();
+
   /// リポジトリを閉じる（リソースのクリーンアップ）
   Future<void> close();
 }

--- a/lib/services/stats_service.dart
+++ b/lib/services/stats_service.dart
@@ -1,0 +1,285 @@
+import '../models/review_log.dart';
+import '../repositories/srs_repository.dart';
+import '../repositories/post_repository.dart';
+
+/// 学習統計データ
+class LearningStats {
+  final int todayReviews;
+  final int weekReviews;
+  final int monthReviews;
+  final int streakDays;
+  final int todayDueCount;
+  final int remainingDueCount;
+  final int totalCards;
+  final int weekCreatedCards;
+  final DateTime lastUpdated;
+
+  const LearningStats({
+    required this.todayReviews,
+    required this.weekReviews,
+    required this.monthReviews,
+    required this.streakDays,
+    required this.todayDueCount,
+    required this.remainingDueCount,
+    required this.totalCards,
+    required this.weekCreatedCards,
+    required this.lastUpdated,
+  });
+
+  LearningStats copyWith({
+    int? todayReviews,
+    int? weekReviews,
+    int? monthReviews,
+    int? streakDays,
+    int? todayDueCount,
+    int? remainingDueCount,
+    int? totalCards,
+    int? weekCreatedCards,
+    DateTime? lastUpdated,
+  }) {
+    return LearningStats(
+      todayReviews: todayReviews ?? this.todayReviews,
+      weekReviews: weekReviews ?? this.weekReviews,
+      monthReviews: monthReviews ?? this.monthReviews,
+      streakDays: streakDays ?? this.streakDays,
+      todayDueCount: todayDueCount ?? this.todayDueCount,
+      remainingDueCount: remainingDueCount ?? this.remainingDueCount,
+      totalCards: totalCards ?? this.totalCards,
+      weekCreatedCards: weekCreatedCards ?? this.weekCreatedCards,
+      lastUpdated: lastUpdated ?? this.lastUpdated,
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'todayReviews': todayReviews,
+      'weekReviews': weekReviews,
+      'monthReviews': monthReviews,
+      'streakDays': streakDays,
+      'todayDueCount': todayDueCount,
+      'remainingDueCount': remainingDueCount,
+      'totalCards': totalCards,
+      'weekCreatedCards': weekCreatedCards,
+      'lastUpdated': lastUpdated.toIso8601String(),
+    };
+  }
+
+  factory LearningStats.fromJson(Map<String, dynamic> json) {
+    return LearningStats(
+      todayReviews: json['todayReviews'] as int,
+      weekReviews: json['weekReviews'] as int,
+      monthReviews: json['monthReviews'] as int,
+      streakDays: json['streakDays'] as int,
+      todayDueCount: json['todayDueCount'] as int,
+      remainingDueCount: json['remainingDueCount'] as int,
+      totalCards: json['totalCards'] as int,
+      weekCreatedCards: json['weekCreatedCards'] as int,
+      lastUpdated: DateTime.parse(json['lastUpdated'] as String),
+    );
+  }
+
+  @override
+  String toString() {
+    return 'LearningStats(todayReviews: $todayReviews, weekReviews: $weekReviews, monthReviews: $monthReviews, streakDays: $streakDays, todayDueCount: $todayDueCount, remainingDueCount: $remainingDueCount, totalCards: $totalCards, weekCreatedCards: $weekCreatedCards, lastUpdated: $lastUpdated)';
+  }
+}
+
+/// 学習統計サービス
+/// SRS学習状況の集計とキャッシュ管理
+class StatsService {
+  final SrsRepository _srsRepository;
+
+  LearningStats? _cachedStats;
+  DateTime? _lastCacheUpdate;
+
+  StatsService({
+    required SrsRepository srsRepository,
+    required PostRepository postRepository,
+  }) : _srsRepository = srsRepository;
+
+  /// 統計データを取得（キャッシュ優先）
+  Future<LearningStats> getStats() async {
+    final now = DateTime.now();
+
+    // キャッシュが有効な場合は返す（5分以内）
+    if (_cachedStats != null &&
+        _lastCacheUpdate != null &&
+        now.difference(_lastCacheUpdate!).inMinutes < 5) {
+      return _cachedStats!;
+    }
+
+    // 統計を再計算
+    final stats = await _calculateStats();
+    _cachedStats = stats;
+    _lastCacheUpdate = now;
+
+    return stats;
+  }
+
+  /// 統計データを強制再計算
+  Future<LearningStats> refreshStats() async {
+    final stats = await _calculateStats();
+    _cachedStats = stats;
+    _lastCacheUpdate = DateTime.now();
+    return stats;
+  }
+
+  /// レビュー完了時の差分更新
+  Future<void> onReviewCompleted(Rating rating) async {
+    if (_cachedStats == null) return;
+
+    final now = DateTime.now();
+    final today = DateTime(now.year, now.month, now.day);
+
+    // 今日のレビュー数を増加
+    _cachedStats = _cachedStats!.copyWith(
+      todayReviews: _cachedStats!.todayReviews + 1,
+      lastUpdated: now,
+    );
+
+    // 週・月のレビュー数も更新
+    final weekStart = _getWeekStart(today);
+    final monthStart = DateTime(today.year, today.month, 1);
+
+    // 実際のデータから週・月のレビュー数を再計算
+    final weekReviews = await _getReviewsInPeriod(weekStart, today);
+    final monthReviews = await _getReviewsInPeriod(monthStart, today);
+
+    _cachedStats = _cachedStats!.copyWith(
+      weekReviews: weekReviews,
+      monthReviews: monthReviews,
+    );
+
+    // Due件数を更新
+    await _updateDueCounts();
+  }
+
+  /// カード作成時の差分更新
+  Future<void> onCardCreated() async {
+    if (_cachedStats == null) return;
+
+    final now = DateTime.now();
+
+    // 今週の作成数を増加
+    _cachedStats = _cachedStats!.copyWith(
+      weekCreatedCards: _cachedStats!.weekCreatedCards + 1,
+      totalCards: _cachedStats!.totalCards + 1,
+      lastUpdated: now,
+    );
+  }
+
+  /// 統計データを計算
+  Future<LearningStats> _calculateStats() async {
+    final now = DateTime.now();
+    final today = DateTime(now.year, now.month, now.day);
+    final weekStart = _getWeekStart(today);
+    final monthStart = DateTime(today.year, today.month, 1);
+    final monthEnd = DateTime(today.year, today.month + 1, 0); // 月の最終日
+
+    // レビュー数の集計
+    final todayReviews = await _getReviewsInPeriod(today, today);
+    final weekReviews = await _getReviewsInPeriod(weekStart, today);
+    final monthReviews = await _getReviewsInPeriod(monthStart, monthEnd);
+
+    // 学習連続日数の計算
+    final streakDays = await _calculateStreakDays();
+
+    // Due件数の計算
+    final dueCards = await _srsRepository.getDueCards();
+    final todayDueCount = dueCards.where((card) => card.isDueToday).length;
+    final remainingDueCount = dueCards.length;
+
+    // カード数の集計
+    final allCards = await _srsRepository.getAllCards();
+    final totalCards = allCards.length;
+    final weekCreatedCards =
+        allCards.where((card) => card.createdAt.isAfter(weekStart)).length;
+
+    return LearningStats(
+      todayReviews: todayReviews,
+      weekReviews: weekReviews,
+      monthReviews: monthReviews,
+      streakDays: streakDays,
+      todayDueCount: todayDueCount,
+      remainingDueCount: remainingDueCount,
+      totalCards: totalCards,
+      weekCreatedCards: weekCreatedCards,
+      lastUpdated: now,
+    );
+  }
+
+  /// 指定期間のレビュー数を取得
+  Future<int> _getReviewsInPeriod(DateTime start, DateTime end) async {
+    final reviewLogs = await _srsRepository.getAllReviewLogs();
+
+    return reviewLogs.where((log) {
+      final logDate = DateTime(
+          log.reviewedAt.year, log.reviewedAt.month, log.reviewedAt.day);
+      return logDate.isAtSameMomentAs(start) ||
+          logDate.isAtSameMomentAs(end) ||
+          (logDate.isAfter(start) && logDate.isBefore(end));
+    }).length;
+  }
+
+  /// 学習連続日数を計算
+  Future<int> _calculateStreakDays() async {
+    final reviewLogs = await _srsRepository.getAllReviewLogs();
+
+    if (reviewLogs.isEmpty) return 0;
+
+    // レビュー日を重複除去してソート
+    final reviewDates = reviewLogs
+        .map((log) => DateTime(
+            log.reviewedAt.year, log.reviewedAt.month, log.reviewedAt.day))
+        .toSet()
+        .toList()
+      ..sort((a, b) => b.compareTo(a)); // 降順ソート
+
+    if (reviewDates.isEmpty) return 0;
+
+    final today = DateTime.now();
+    final todayDate = DateTime(today.year, today.month, today.day);
+
+    // 今日または昨日から連続日数を計算
+    int streak = 0;
+    DateTime currentDate = todayDate;
+
+    for (final reviewDate in reviewDates) {
+      if (reviewDate.isAtSameMomentAs(currentDate) ||
+          reviewDate.isAtSameMomentAs(
+              currentDate.subtract(const Duration(days: 1)))) {
+        streak++;
+        currentDate = reviewDate.subtract(const Duration(days: 1));
+      } else {
+        break;
+      }
+    }
+
+    return streak;
+  }
+
+  /// Due件数を更新
+  Future<void> _updateDueCounts() async {
+    final dueCards = await _srsRepository.getDueCards();
+    final todayDueCount = dueCards.where((card) => card.isDueToday).length;
+    final remainingDueCount = dueCards.length;
+
+    _cachedStats = _cachedStats!.copyWith(
+      todayDueCount: todayDueCount,
+      remainingDueCount: remainingDueCount,
+    );
+  }
+
+  /// 週の開始日を取得（月曜日）
+  DateTime _getWeekStart(DateTime date) {
+    final weekday = date.weekday;
+    final daysToSubtract = weekday == 1 ? 0 : weekday - 1;
+    return date.subtract(Duration(days: daysToSubtract));
+  }
+
+  /// キャッシュをクリア
+  void clearCache() {
+    _cachedStats = null;
+    _lastCacheUpdate = null;
+  }
+}

--- a/test/services/stats_service_test.dart
+++ b/test/services/stats_service_test.dart
@@ -23,7 +23,10 @@ class MockSrsRepository implements SrsRepository {
   @override
   Future<List<SrsCard>> listDueCards({DateTime? now, int limit = 20}) async {
     final dueDate = now ?? DateTime.now();
-    return _cards.where((card) => card.due.isBefore(dueDate)).take(limit).toList();
+    return _cards
+        .where((card) => card.due.isBefore(dueDate))
+        .take(limit)
+        .toList();
   }
 
   @override
@@ -82,7 +85,8 @@ class MockSrsRepository implements SrsRepository {
     final todayEnd = todayStart.add(const Duration(days: 1));
 
     return _reviewLogs.where((log) {
-      return log.reviewedAt.isAfter(todayStart) && log.reviewedAt.isBefore(todayEnd);
+      return log.reviewedAt.isAfter(todayStart) &&
+          log.reviewedAt.isBefore(todayEnd);
     }).length;
   }
 
@@ -102,8 +106,8 @@ class MockSrsRepository implements SrsRepository {
   Future<void> close() async {}
 
   @override
-  Future<int> createCardsFromCandidates(
-          List<dynamic> candidates, String sourcePostId, String sourceSnippet) async =>
+  Future<int> createCardsFromCandidates(List<dynamic> candidates,
+          String sourcePostId, String sourceSnippet) async =>
       0;
 
   @override
@@ -128,7 +132,9 @@ class MockPostRepository implements PostRepository {
 
   @override
   Future<Post> createPost(
-      {required XFile image, required String raw, required String normalized}) async {
+      {required XFile image,
+      required String raw,
+      required String normalized}) async {
     return Post(
       id: 'test_id',
       imagePath: image.path,
@@ -146,7 +152,8 @@ class MockPostRepository implements PostRepository {
   @override
   Future<void> deletePost(String id) async {}
 
-  Future<List<Post>> getPostsByDateRange(DateTime start, DateTime end) async => [];
+  Future<List<Post>> getPostsByDateRange(DateTime start, DateTime end) async =>
+      [];
 
   @override
   Future<void> close() async {}
@@ -167,7 +174,8 @@ class MockPostRepository implements PostRepository {
   Future<void> importPosts(List<Map<String, dynamic>> postsData) async {}
 
   @override
-  Future<List<Post>> searchPosts({required String query, int limit = 100, int offset = 0}) async =>
+  Future<List<Post>> searchPosts(
+          {required String query, int limit = 100, int offset = 0}) async =>
       [];
 
   @override

--- a/test/services/stats_service_test.dart
+++ b/test/services/stats_service_test.dart
@@ -1,11 +1,11 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:image_picker/image_picker.dart';
-import '../../lib/services/stats_service.dart';
-import '../../lib/models/srs_card.dart';
-import '../../lib/models/review_log.dart';
-import '../../lib/models/post.dart';
-import '../../lib/repositories/srs_repository.dart';
-import '../../lib/repositories/post_repository.dart';
+import 'package:snap_jp_learn_app/services/stats_service.dart';
+import 'package:snap_jp_learn_app/models/srs_card.dart';
+import 'package:snap_jp_learn_app/models/review_log.dart';
+import 'package:snap_jp_learn_app/models/post.dart';
+import 'package:snap_jp_learn_app/repositories/srs_repository.dart';
+import 'package:snap_jp_learn_app/repositories/post_repository.dart';
 
 // モックリポジトリ
 class MockSrsRepository implements SrsRepository {
@@ -23,10 +23,7 @@ class MockSrsRepository implements SrsRepository {
   @override
   Future<List<SrsCard>> listDueCards({DateTime? now, int limit = 20}) async {
     final dueDate = now ?? DateTime.now();
-    return _cards
-        .where((card) => card.due.isBefore(dueDate))
-        .take(limit)
-        .toList();
+    return _cards.where((card) => card.due.isBefore(dueDate)).take(limit).toList();
   }
 
   @override
@@ -85,8 +82,7 @@ class MockSrsRepository implements SrsRepository {
     final todayEnd = todayStart.add(const Duration(days: 1));
 
     return _reviewLogs.where((log) {
-      return log.reviewedAt.isAfter(todayStart) &&
-          log.reviewedAt.isBefore(todayEnd);
+      return log.reviewedAt.isAfter(todayStart) && log.reviewedAt.isBefore(todayEnd);
     }).length;
   }
 
@@ -106,8 +102,8 @@ class MockSrsRepository implements SrsRepository {
   Future<void> close() async {}
 
   @override
-  Future<int> createCardsFromCandidates(List<dynamic> candidates,
-          String sourcePostId, String sourceSnippet) async =>
+  Future<int> createCardsFromCandidates(
+          List<dynamic> candidates, String sourcePostId, String sourceSnippet) async =>
       0;
 
   @override
@@ -125,16 +121,14 @@ class MockSrsRepository implements SrsRepository {
 
 class MockPostRepository implements PostRepository {
   @override
-  Future<List<Post>> getAllPosts() async => [];
+  Future<List<Post>> listPosts({int limit = 100, int offset = 0}) async => [];
 
   @override
   Future<Post?> getPost(String id) async => null;
 
   @override
   Future<Post> createPost(
-      {required XFile image,
-      required String raw,
-      required String normalized}) async {
+      {required XFile image, required String raw, required String normalized}) async {
     return Post(
       id: 'test_id',
       imagePath: image.path,
@@ -147,15 +141,12 @@ class MockPostRepository implements PostRepository {
     );
   }
 
-  @override
   Future<Post> updatePost(Post post) async => post;
 
   @override
   Future<void> deletePost(String id) async {}
 
-  @override
-  Future<List<Post>> getPostsByDateRange(DateTime start, DateTime end) async =>
-      [];
+  Future<List<Post>> getPostsByDateRange(DateTime start, DateTime end) async => [];
 
   @override
   Future<void> close() async {}
@@ -176,11 +167,7 @@ class MockPostRepository implements PostRepository {
   Future<void> importPosts(List<Map<String, dynamic>> postsData) async {}
 
   @override
-  Future<List<Post>> listPosts({int limit = 100, int offset = 0}) async => [];
-
-  @override
-  Future<List<Post>> searchPosts(
-          {required String query, int limit = 100, int offset = 0}) async =>
+  Future<List<Post>> searchPosts({required String query, int limit = 100, int offset = 0}) async =>
       [];
 
   @override

--- a/test/services/stats_service_test.dart
+++ b/test/services/stats_service_test.dart
@@ -1,0 +1,613 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:image_picker/image_picker.dart';
+import '../../lib/services/stats_service.dart';
+import '../../lib/models/srs_card.dart';
+import '../../lib/models/review_log.dart';
+import '../../lib/models/post.dart';
+import '../../lib/repositories/srs_repository.dart';
+import '../../lib/repositories/post_repository.dart';
+
+// モックリポジトリ
+class MockSrsRepository implements SrsRepository {
+  final List<SrsCard> _cards = [];
+  final List<ReviewLog> _reviewLogs = [];
+
+  void addCard(SrsCard card) {
+    _cards.add(card);
+  }
+
+  void addReviewLog(ReviewLog log) {
+    _reviewLogs.add(log);
+  }
+
+  @override
+  Future<List<SrsCard>> listDueCards({DateTime? now, int limit = 20}) async {
+    final dueDate = now ?? DateTime.now();
+    return _cards
+        .where((card) => card.due.isBefore(dueDate))
+        .take(limit)
+        .toList();
+  }
+
+  @override
+  Future<SrsCard> upsertCard(SrsCard card) async {
+    final index = _cards.indexWhere((c) => c.id == card.id);
+    if (index >= 0) {
+      _cards[index] = card;
+    } else {
+      _cards.add(card);
+    }
+    return card;
+  }
+
+  @override
+  Future<void> review(String cardId, Rating rating, DateTime now) async {
+    // モック実装
+  }
+
+  @override
+  Future<List<SrsCard>> listByPost(String postId) async {
+    return _cards.where((card) => card.sourcePostId == postId).toList();
+  }
+
+  @override
+  Future<void> deleteByPost(String postId) async {
+    _cards.removeWhere((card) => card.sourcePostId == postId);
+  }
+
+  @override
+  Future<void> deleteCard(String cardId) async {
+    _cards.removeWhere((card) => card.id == cardId);
+  }
+
+  @override
+  Future<SrsCard?> getCard(String cardId) async {
+    try {
+      return _cards.firstWhere((card) => card.id == cardId);
+    } catch (e) {
+      return null;
+    }
+  }
+
+  @override
+  Future<int> getCardCount() async => _cards.length;
+
+  @override
+  Future<int> getDueCardCount({DateTime? now}) async {
+    final dueDate = now ?? DateTime.now();
+    return _cards.where((card) => card.due.isBefore(dueDate)).length;
+  }
+
+  @override
+  Future<int> getTodayReviewCount() async {
+    final today = DateTime.now();
+    final todayStart = DateTime(today.year, today.month, today.day);
+    final todayEnd = todayStart.add(const Duration(days: 1));
+
+    return _reviewLogs.where((log) {
+      return log.reviewedAt.isAfter(todayStart) &&
+          log.reviewedAt.isBefore(todayEnd);
+    }).length;
+  }
+
+  @override
+  Future<List<SrsCard>> getAllCards() async => List.from(_cards);
+
+  @override
+  Future<List<SrsCard>> getDueCards() async {
+    final now = DateTime.now();
+    return _cards.where((card) => card.due.isBefore(now)).toList();
+  }
+
+  @override
+  Future<List<ReviewLog>> getAllReviewLogs() async => List.from(_reviewLogs);
+
+  @override
+  Future<void> close() async {}
+
+  @override
+  Future<int> createCardsFromCandidates(List<dynamic> candidates,
+          String sourcePostId, String sourceSnippet) async =>
+      0;
+
+  @override
+  Future<Map<String, dynamic>?> getCardStats(String cardId) async => null;
+
+  @override
+  Future<Map<String, int>> getCardsByStatus() async => {};
+
+  @override
+  Future<List<ReviewLog>> getReviewLogsByCard(String cardId) async => [];
+
+  @override
+  Future<List<ReviewLog>> getReviewLogsByDate(DateTime date) async => [];
+}
+
+class MockPostRepository implements PostRepository {
+  @override
+  Future<List<Post>> getAllPosts() async => [];
+
+  @override
+  Future<Post?> getPost(String id) async => null;
+
+  @override
+  Future<Post> createPost(
+      {required XFile image,
+      required String raw,
+      required String normalized}) async {
+    return Post(
+      id: 'test_id',
+      imagePath: image.path,
+      rawText: raw,
+      normalizedText: normalized,
+      createdAt: DateTime.now(),
+      likeCount: 0,
+      learnedCount: 0,
+      learned: false,
+    );
+  }
+
+  @override
+  Future<Post> updatePost(Post post) async => post;
+
+  @override
+  Future<void> deletePost(String id) async {}
+
+  @override
+  Future<List<Post>> getPostsByDateRange(DateTime start, DateTime end) async =>
+      [];
+
+  @override
+  Future<void> close() async {}
+
+  @override
+  Future<List<Map<String, dynamic>>> exportPosts() async => [];
+
+  @override
+  Future<int> getLearnedPostCount() async => 0;
+
+  @override
+  Future<int> getLikedPostCount() async => 0;
+
+  @override
+  Future<int> getPostCount() async => 0;
+
+  @override
+  Future<void> importPosts(List<Map<String, dynamic>> postsData) async {}
+
+  @override
+  Future<List<Post>> listPosts({int limit = 100, int offset = 0}) async => [];
+
+  @override
+  Future<List<Post>> searchPosts(
+          {required String query, int limit = 100, int offset = 0}) async =>
+      [];
+
+  @override
+  Future<void> toggleLearned(String id) async {}
+
+  @override
+  Future<void> toggleLike(String id) async {}
+}
+
+void main() {
+  group('StatsService Tests', () {
+    late StatsService statsService;
+    late MockSrsRepository mockSrsRepository;
+    late MockPostRepository mockPostRepository;
+
+    setUp(() {
+      mockSrsRepository = MockSrsRepository();
+      mockPostRepository = MockPostRepository();
+      statsService = StatsService(
+        srsRepository: mockSrsRepository,
+        postRepository: mockPostRepository,
+      );
+    });
+
+    test('should calculate stats correctly with empty data', () async {
+      final stats = await statsService.getStats();
+
+      expect(stats.todayReviews, 0);
+      expect(stats.weekReviews, 0);
+      expect(stats.monthReviews, 0);
+      expect(stats.streakDays, 0);
+      expect(stats.todayDueCount, 0);
+      expect(stats.remainingDueCount, 0);
+      expect(stats.totalCards, 0);
+      expect(stats.weekCreatedCards, 0);
+    });
+
+    test('should calculate today reviews correctly', () async {
+      final now = DateTime.now();
+      final today = DateTime(now.year, now.month, now.day);
+
+      // 今日のレビューログを追加
+      mockSrsRepository.addReviewLog(ReviewLog(
+        id: '1',
+        cardId: 'card1',
+        reviewedAt: today.add(const Duration(hours: 10)),
+        rating: Rating.good.value,
+      ));
+
+      mockSrsRepository.addReviewLog(ReviewLog(
+        id: '2',
+        cardId: 'card2',
+        reviewedAt: today.add(const Duration(hours: 15)),
+        rating: Rating.easy.value,
+      ));
+
+      final stats = await statsService.getStats();
+
+      expect(stats.todayReviews, 2);
+    });
+
+    test('should calculate week reviews correctly', () async {
+      final now = DateTime.now();
+      final today = DateTime(now.year, now.month, now.day);
+      final weekStart = _getWeekStart(today);
+
+      // 今週のレビューログを追加
+      for (int i = 0; i < 3; i++) {
+        mockSrsRepository.addReviewLog(ReviewLog(
+          id: 'log$i',
+          cardId: 'card$i',
+          reviewedAt: weekStart.add(Duration(days: i)),
+          rating: Rating.good.value,
+        ));
+      }
+
+      final stats = await statsService.getStats();
+
+      expect(stats.weekReviews, 3);
+    });
+
+    test('should calculate month reviews correctly', () async {
+      final now = DateTime.now();
+      final monthStart = DateTime(now.year, now.month, 1);
+
+      // 今月のレビューログを追加（確実に月内に収まるように）
+      mockSrsRepository.addReviewLog(ReviewLog(
+        id: 'log1',
+        cardId: 'card1',
+        reviewedAt: monthStart.add(const Duration(days: 1)),
+        rating: Rating.good.value,
+      ));
+
+      mockSrsRepository.addReviewLog(ReviewLog(
+        id: 'log2',
+        cardId: 'card2',
+        reviewedAt: monthStart.add(const Duration(days: 5)),
+        rating: Rating.good.value,
+      ));
+
+      mockSrsRepository.addReviewLog(ReviewLog(
+        id: 'log3',
+        cardId: 'card3',
+        reviewedAt: monthStart.add(const Duration(days: 10)),
+        rating: Rating.good.value,
+      ));
+
+      mockSrsRepository.addReviewLog(ReviewLog(
+        id: 'log4',
+        cardId: 'card4',
+        reviewedAt: monthStart.add(const Duration(days: 15)),
+        rating: Rating.good.value,
+      ));
+
+      mockSrsRepository.addReviewLog(ReviewLog(
+        id: 'log5',
+        cardId: 'card5',
+        reviewedAt: monthStart.add(const Duration(days: 20)),
+        rating: Rating.good.value,
+      ));
+
+      final stats = await statsService.getStats();
+
+      expect(stats.monthReviews, 5);
+    });
+
+    test('should calculate streak days correctly', () async {
+      final now = DateTime.now();
+      final today = DateTime(now.year, now.month, now.day);
+
+      // 連続3日間のレビューログを追加
+      mockSrsRepository.addReviewLog(ReviewLog(
+        id: '1',
+        cardId: 'card1',
+        reviewedAt: today,
+        rating: Rating.good.value,
+      ));
+
+      mockSrsRepository.addReviewLog(ReviewLog(
+        id: '2',
+        cardId: 'card2',
+        reviewedAt: today.subtract(const Duration(days: 1)),
+        rating: Rating.good.value,
+      ));
+
+      mockSrsRepository.addReviewLog(ReviewLog(
+        id: '3',
+        cardId: 'card3',
+        reviewedAt: today.subtract(const Duration(days: 2)),
+        rating: Rating.good.value,
+      ));
+
+      final stats = await statsService.getStats();
+
+      expect(stats.streakDays, 3);
+    });
+
+    test('should calculate due counts correctly', () async {
+      final now = DateTime.now();
+
+      // Dueカードを追加
+      mockSrsRepository.addCard(SrsCard(
+        id: 'card1',
+        term: '学校',
+        reading: 'がっこう',
+        meaning: '教育機関',
+        sourcePostId: 'post1',
+        sourceSnippet: '学校で勉強する',
+        createdAt: now.subtract(const Duration(days: 1)),
+        due: now.subtract(const Duration(hours: 1)), // 過去のDue
+        interval: 1,
+        easeFactor: 2.5,
+        repetition: 1,
+      ));
+
+      mockSrsRepository.addCard(SrsCard(
+        id: 'card2',
+        term: '学生',
+        reading: 'がくせい',
+        meaning: '学校に通う人',
+        sourcePostId: 'post1',
+        sourceSnippet: '学生が勉強する',
+        createdAt: now.subtract(const Duration(days: 1)),
+        due: now.add(const Duration(hours: 1)), // 未来のDue
+        interval: 1,
+        easeFactor: 2.5,
+        repetition: 1,
+      ));
+
+      final stats = await statsService.getStats();
+
+      expect(stats.todayDueCount, 1); // 今日Dueのカード数
+      expect(stats.remainingDueCount, 1); // 残りDueのカード数
+    });
+
+    test('should calculate card counts correctly', () async {
+      final now = DateTime.now();
+      final weekStart = _getWeekStart(DateTime(now.year, now.month, now.day));
+
+      // 古いカード
+      mockSrsRepository.addCard(SrsCard(
+        id: 'card1',
+        term: '学校',
+        reading: 'がっこう',
+        meaning: '教育機関',
+        sourcePostId: 'post1',
+        sourceSnippet: '学校で勉強する',
+        createdAt: now.subtract(const Duration(days: 10)),
+        due: now,
+        interval: 1,
+        easeFactor: 2.5,
+        repetition: 1,
+      ));
+
+      // 今週作成のカード
+      mockSrsRepository.addCard(SrsCard(
+        id: 'card2',
+        term: '学生',
+        reading: 'がくせい',
+        meaning: '学校に通う人',
+        sourcePostId: 'post1',
+        sourceSnippet: '学生が勉強する',
+        createdAt: weekStart.add(const Duration(days: 2)),
+        due: now,
+        interval: 1,
+        easeFactor: 2.5,
+        repetition: 1,
+      ));
+
+      final stats = await statsService.getStats();
+
+      expect(stats.totalCards, 2);
+      expect(stats.weekCreatedCards, 1);
+    });
+
+    test('should update stats on review completed', () async {
+      // 初期統計を取得
+      final initialStats = await statsService.getStats();
+      expect(initialStats.todayReviews, 0);
+
+      // レビュー完了をシミュレート
+      await statsService.onReviewCompleted(Rating.good);
+
+      // 統計が更新されていることを確認
+      final updatedStats = await statsService.getStats();
+      expect(updatedStats.todayReviews, 1);
+    });
+
+    test('should update stats on card created', () async {
+      // 初期統計を取得
+      final initialStats = await statsService.getStats();
+      expect(initialStats.totalCards, 0);
+      expect(initialStats.weekCreatedCards, 0);
+
+      // カード作成をシミュレート
+      await statsService.onCardCreated();
+
+      // 統計が更新されていることを確認
+      final updatedStats = await statsService.getStats();
+      expect(updatedStats.totalCards, 1);
+      expect(updatedStats.weekCreatedCards, 1);
+    });
+
+    test('should cache stats for performance', () async {
+      // 初回取得
+      final stats1 = await statsService.getStats();
+
+      // 2回目取得（キャッシュから）
+      final stats2 = await statsService.getStats();
+
+      // 同じオブジェクトであることを確認（キャッシュ）
+      expect(stats1, same(stats2));
+    });
+
+    test('should refresh stats when requested', () async {
+      // 初回取得
+      final stats1 = await statsService.getStats();
+
+      // 強制更新
+      final stats2 = await statsService.refreshStats();
+
+      // 異なるオブジェクトであることを確認（更新）
+      expect(stats1, isNot(same(stats2)));
+    });
+
+    test('should clear cache', () {
+      statsService.clearCache();
+      // キャッシュクリア後は再計算される
+      expect(statsService.getStats(), isA<Future<LearningStats>>());
+    });
+  });
+
+  group('LearningStats Tests', () {
+    test('should be created with required fields', () {
+      final now = DateTime.now();
+      final stats = LearningStats(
+        todayReviews: 5,
+        weekReviews: 20,
+        monthReviews: 80,
+        streakDays: 7,
+        todayDueCount: 3,
+        remainingDueCount: 10,
+        totalCards: 100,
+        weekCreatedCards: 5,
+        lastUpdated: now,
+      );
+
+      expect(stats.todayReviews, 5);
+      expect(stats.weekReviews, 20);
+      expect(stats.monthReviews, 80);
+      expect(stats.streakDays, 7);
+      expect(stats.todayDueCount, 3);
+      expect(stats.remainingDueCount, 10);
+      expect(stats.totalCards, 100);
+      expect(stats.weekCreatedCards, 5);
+      expect(stats.lastUpdated, now);
+    });
+
+    test('copyWith should create new instance with updated fields', () {
+      final now = DateTime.now();
+      final original = LearningStats(
+        todayReviews: 5,
+        weekReviews: 20,
+        monthReviews: 80,
+        streakDays: 7,
+        todayDueCount: 3,
+        remainingDueCount: 10,
+        totalCards: 100,
+        weekCreatedCards: 5,
+        lastUpdated: now,
+      );
+
+      final updated = original.copyWith(
+        todayReviews: 6,
+        streakDays: 8,
+      );
+
+      expect(updated.todayReviews, 6);
+      expect(updated.weekReviews, 20); // 変更なし
+      expect(updated.streakDays, 8);
+      expect(updated.todayDueCount, 3); // 変更なし
+    });
+
+    test('toJson should serialize correctly', () {
+      final now = DateTime.now();
+      final stats = LearningStats(
+        todayReviews: 5,
+        weekReviews: 20,
+        monthReviews: 80,
+        streakDays: 7,
+        todayDueCount: 3,
+        remainingDueCount: 10,
+        totalCards: 100,
+        weekCreatedCards: 5,
+        lastUpdated: now,
+      );
+
+      final json = stats.toJson();
+
+      expect(json['todayReviews'], 5);
+      expect(json['weekReviews'], 20);
+      expect(json['monthReviews'], 80);
+      expect(json['streakDays'], 7);
+      expect(json['todayDueCount'], 3);
+      expect(json['remainingDueCount'], 10);
+      expect(json['totalCards'], 100);
+      expect(json['weekCreatedCards'], 5);
+      expect(json['lastUpdated'], now.toIso8601String());
+    });
+
+    test('fromJson should deserialize correctly', () {
+      final now = DateTime.now();
+      final json = {
+        'todayReviews': 5,
+        'weekReviews': 20,
+        'monthReviews': 80,
+        'streakDays': 7,
+        'todayDueCount': 3,
+        'remainingDueCount': 10,
+        'totalCards': 100,
+        'weekCreatedCards': 5,
+        'lastUpdated': now.toIso8601String(),
+      };
+
+      final stats = LearningStats.fromJson(json);
+
+      expect(stats.todayReviews, 5);
+      expect(stats.weekReviews, 20);
+      expect(stats.monthReviews, 80);
+      expect(stats.streakDays, 7);
+      expect(stats.todayDueCount, 3);
+      expect(stats.remainingDueCount, 10);
+      expect(stats.totalCards, 100);
+      expect(stats.weekCreatedCards, 5);
+      expect(stats.lastUpdated, now);
+    });
+
+    test('toString should return readable string', () {
+      final now = DateTime.now();
+      final stats = LearningStats(
+        todayReviews: 5,
+        weekReviews: 20,
+        monthReviews: 80,
+        streakDays: 7,
+        todayDueCount: 3,
+        remainingDueCount: 10,
+        totalCards: 100,
+        weekCreatedCards: 5,
+        lastUpdated: now,
+      );
+
+      final str = stats.toString();
+
+      expect(str, contains('5'));
+      expect(str, contains('20'));
+      expect(str, contains('80'));
+      expect(str, contains('7'));
+      expect(str, contains('3'));
+      expect(str, contains('10'));
+      expect(str, contains('100'));
+    });
+  });
+}
+
+// ヘルパー関数
+DateTime _getWeekStart(DateTime date) {
+  final weekday = date.weekday;
+  final daysToSubtract = weekday == 1 ? 0 : weekday - 1;
+  return date.subtract(Duration(days: daysToSubtract));
+}


### PR DESCRIPTION
- Add StatsService for comprehensive learning statistics calculation
- Implement LearningStats model with today/week/month reviews, streak, due counts
- Create StatsPage UI with card-based metrics display
- Add navigation from HomePage to StatsPage via AppBar menu
- Integrate stats updates on review completion and card creation
- Add comprehensive test coverage for StatsService functionality
- Support caching for performance optimization
- Calculate learning streak, due cards, and card creation statistics

This provides:
- Real-time learning progress visualization
- Motivation through streak tracking
- Due card management insights
- Comprehensive learning analytics
- Seamless integration with existing SRS system