### PR TITLE
fix: update Android build configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,15 @@
 
 ## セットアップ
 
+### 0. 必要な環境
+
+**初回セットアップは Android SDK 36 / NDK 27.0.12077973 が必要です**
+
+- Android Studio で Android SDK 36 をインストール
+- Android NDK 27.0.12077973 をインストール
+- Flutter 3.19以上
+- Dart 3.x（null-safety対応）
+
 ### 1. 依存関係のインストール
 
 ```bash

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -7,8 +7,8 @@ plugins {
 
 android {
     namespace = "com.example.snap_jp_learn_app"
-    compileSdk = flutter.compileSdkVersion
-    ndkVersion = flutter.ndkVersion
+    compileSdk = 36
+    ndkVersion = "27.0.12077973"
 
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_11
@@ -25,7 +25,7 @@ android {
         // You can update the following values to match your application needs.
         // For more information, see: https://flutter.dev/to/review-gradle-config.
         minSdk = flutter.minSdkVersion
-        targetSdk = flutter.targetSdkVersion
+        targetSdk = 36
         versionCode = flutter.versionCode
         versionName = flutter.versionName
     }


### PR DESCRIPTION
- Update compileSdk to 36
- Set targetSdk to 36
- Fix NDK version to 27.0.12077973
- Add setup requirements to README

This resolves camera and ML Kit plugin dependency warnings and ensures compatibility with latest Android SDK.