### PR TITLE
feat: Implement local analytics dashboard with opt-in controls

### DIFF
--- a/lib/pages/stats_dashboard_page.dart
+++ b/lib/pages/stats_dashboard_page.dart
@@ -1,0 +1,491 @@
+import 'dart:io';
+import 'dart:ui' as ui;
+import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
+import 'package:flutter/services.dart';
+import 'package:share_plus/share_plus.dart';
+import '../services/stats_dashboard_service.dart';
+import '../widgets/stats_chart.dart';
+
+class StatsDashboardPage extends StatefulWidget {
+  const StatsDashboardPage({super.key});
+
+  @override
+  State<StatsDashboardPage> createState() => _StatsDashboardPageState();
+}
+
+class _StatsDashboardPageState extends State<StatsDashboardPage> {
+  DashboardStats? _stats;
+  bool _isLoading = true;
+  bool _isRefreshing = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadStats();
+  }
+
+  /// 統計データを読み込み
+  Future<void> _loadStats() async {
+    setState(() {
+      _isLoading = true;
+    });
+
+    try {
+      final stats = await StatsDashboardService.instance.getStats();
+      if (mounted) {
+        setState(() {
+          _stats = stats;
+          _isLoading = false;
+        });
+      }
+    } catch (e) {
+      if (mounted) {
+        setState(() {
+          _isLoading = false;
+        });
+        _showErrorSnackBar('統計データの読み込みに失敗しました: $e');
+      }
+    }
+  }
+
+  /// 統計データを更新
+  Future<void> _refreshStats() async {
+    setState(() {
+      _isRefreshing = true;
+    });
+
+    try {
+      final stats = await StatsDashboardService.instance.refreshStats();
+      if (mounted) {
+        setState(() {
+          _stats = stats;
+          _isRefreshing = false;
+        });
+        _showSuccessSnackBar('統計データを更新しました');
+      }
+    } catch (e) {
+      if (mounted) {
+        setState(() {
+          _isRefreshing = false;
+        });
+        _showErrorSnackBar('統計データの更新に失敗しました: $e');
+      }
+    }
+  }
+
+  /// スクリーンショットを撮影して共有
+  Future<void> _shareScreenshot() async {
+    try {
+      // スクリーンショットを撮影
+      final image = await _captureScreenshot();
+
+      if (image != null) {
+        // 一時ファイルに保存
+        final tempPath = await _saveImageToTemp(image);
+
+        // 共有
+        await Share.shareXFiles(
+          [XFile(tempPath)],
+          text: 'Snap JP Learn - 学習統計ダッシュボード\n\n'
+              '📊 今月の学習成果\n'
+              '📝 投稿数: ${_stats?.totalPosts ?? 0}件\n'
+              '🔍 OCR回数: ${_stats?.totalOcrCount ?? 0}回\n'
+              '✅ 学習完了: ${_stats?.completedCards ?? 0}カード\n'
+              '🔥 継続日数: ${_stats?.streakDays ?? 0}日',
+        );
+      }
+    } catch (e) {
+      _showErrorSnackBar('スクリーンショットの共有に失敗しました: $e');
+    }
+  }
+
+  /// スクリーンショットをキャッチ
+  Future<Uint8List?> _captureScreenshot() async {
+    try {
+      // RepaintBoundaryでラップされたウィジェットから画像を生成
+      final boundary = _screenshotKey.currentContext?.findRenderObject()
+          as RenderRepaintBoundary?;
+      final image = await boundary?.toImage(pixelRatio: 2.0);
+      final byteData = await image?.toByteData(format: ui.ImageByteFormat.png);
+      return byteData?.buffer.asUint8List();
+    } catch (e) {
+      debugPrint('Screenshot capture failed: $e');
+      return null;
+    }
+  }
+
+  /// 画像を一時ファイルに保存
+  Future<String> _saveImageToTemp(Uint8List imageBytes) async {
+    final tempDir = await Directory.systemTemp.createTemp('snap_jp_stats_');
+    final file = File('${tempDir.path}/stats_dashboard.png');
+    await file.writeAsBytes(imageBytes);
+    return file.path;
+  }
+
+  final GlobalKey _screenshotKey = GlobalKey();
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('学習統計ダッシュボード'),
+        backgroundColor: Theme.of(context).colorScheme.inversePrimary,
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.refresh),
+            onPressed: _isRefreshing ? null : _refreshStats,
+          ),
+          IconButton(
+            icon: const Icon(Icons.share),
+            onPressed: _stats != null ? _shareScreenshot : null,
+            tooltip: 'スクリーンショットを共有',
+          ),
+        ],
+      ),
+      body: _buildBody(),
+    );
+  }
+
+  Widget _buildBody() {
+    if (_isLoading) {
+      return const Center(
+        child: CircularProgressIndicator(),
+      );
+    }
+
+    if (_stats == null) {
+      return _buildErrorState();
+    }
+
+    return RefreshIndicator(
+      onRefresh: _refreshStats,
+      child: RepaintBoundary(
+        key: _screenshotKey,
+        child: SingleChildScrollView(
+          physics: const AlwaysScrollableScrollPhysics(),
+          padding: const EdgeInsets.all(16),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              _buildHeader(),
+              const SizedBox(height: 16),
+              _buildStatsCards(),
+              const SizedBox(height: 16),
+              _buildDailyActivityChart(),
+              const SizedBox(height: 16),
+              _buildTagFrequencyChart(),
+              const SizedBox(height: 16),
+              _buildCardProgressChart(),
+              const SizedBox(height: 16),
+              _buildFooter(),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  /// ヘッダーセクション
+  Widget _buildHeader() {
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                Icon(
+                  Icons.dashboard,
+                  color: Theme.of(context).primaryColor,
+                  size: 28,
+                ),
+                const SizedBox(width: 12),
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        '学習統計ダッシュボード',
+                        style:
+                            Theme.of(context).textTheme.headlineSmall?.copyWith(
+                                  fontWeight: FontWeight.bold,
+                                ),
+                      ),
+                      Text(
+                        '最終更新: ${_formatDateTime(_stats!.lastUpdated)}',
+                        style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                              color: Colors.grey[600],
+                            ),
+                      ),
+                    ],
+                  ),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  /// 統計カード
+  Widget _buildStatsCards() {
+    return Column(
+      children: [
+        Row(
+          children: [
+            Expanded(
+              child: StatsCard(
+                title: '投稿数',
+                value: '${_stats!.totalPosts}',
+                subtitle: '今月の投稿',
+                icon: Icons.note_add,
+                color: Colors.blue,
+              ),
+            ),
+            const SizedBox(width: 12),
+            Expanded(
+              child: StatsCard(
+                title: 'OCR回数',
+                value: '${_stats!.totalOcrCount}',
+                subtitle: '文字認識実行',
+                icon: Icons.text_fields,
+                color: Colors.green,
+              ),
+            ),
+          ],
+        ),
+        const SizedBox(height: 12),
+        Row(
+          children: [
+            Expanded(
+              child: StatsCard(
+                title: '学習完了',
+                value: '${_stats!.completedCards}',
+                subtitle: 'カード数',
+                icon: Icons.check_circle,
+                color: Colors.orange,
+              ),
+            ),
+            const SizedBox(width: 12),
+            Expanded(
+              child: StatsCard(
+                title: '継続日数',
+                value: '${_stats!.streakDays}',
+                subtitle: '連続学習',
+                icon: Icons.local_fire_department,
+                color: Colors.red,
+              ),
+            ),
+          ],
+        ),
+      ],
+    );
+  }
+
+  /// 日別活動チャート
+  Widget _buildDailyActivityChart() {
+    return StatsSection(
+      title: '過去30日の活動',
+      trailing: Icon(
+        Icons.trending_up,
+        color: Colors.blue,
+        size: 20,
+      ),
+      child: StatsChart(
+        stats: _stats!,
+        chartType: ChartType.dailyActivity,
+        height: 200,
+      ),
+    );
+  }
+
+  /// タグ頻度チャート
+  Widget _buildTagFrequencyChart() {
+    return StatsSection(
+      title: 'よく使うタグ',
+      trailing: Icon(
+        Icons.label,
+        color: Colors.green,
+        size: 20,
+      ),
+      child: Column(
+        children: [
+          StatsChart(
+            stats: _stats!,
+            chartType: ChartType.tagFrequency,
+            height: 200,
+          ),
+          if (_stats!.topTags.isNotEmpty) ...[
+            const SizedBox(height: 16),
+            _buildTagList(),
+          ],
+        ],
+      ),
+    );
+  }
+
+  /// タグリスト
+  Widget _buildTagList() {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: _stats!.topTags
+          .map((tag) => Padding(
+                padding: const EdgeInsets.symmetric(vertical: 4),
+                child: Row(
+                  children: [
+                    Container(
+                      width: 12,
+                      height: 12,
+                      decoration: BoxDecoration(
+                        color: Colors.blue,
+                        shape: BoxShape.circle,
+                      ),
+                    ),
+                    const SizedBox(width: 8),
+                    Expanded(
+                      child: Text(tag.tag),
+                    ),
+                    Text(
+                      '${tag.count}回 (${tag.percentage.toStringAsFixed(1)}%)',
+                      style: TextStyle(
+                        color: Colors.grey[600],
+                        fontSize: 12,
+                      ),
+                    ),
+                  ],
+                ),
+              ))
+          .toList(),
+    );
+  }
+
+  /// カード進捗チャート
+  Widget _buildCardProgressChart() {
+    return StatsSection(
+      title: 'カード進捗',
+      trailing: Icon(
+        Icons.analytics,
+        color: Colors.purple,
+        size: 20,
+      ),
+      child: StatsChart(
+        stats: _stats!,
+        chartType: ChartType.cardProgress,
+        height: 200,
+      ),
+    );
+  }
+
+  /// フッター
+  Widget _buildFooter() {
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                Icon(
+                  Icons.info_outline,
+                  color: Colors.grey[600],
+                  size: 20,
+                ),
+                const SizedBox(width: 8),
+                Text(
+                  '統計情報について',
+                  style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                        fontWeight: FontWeight.bold,
+                      ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 8),
+            Text(
+              'この統計は、アプリ内の学習データから自動的に計算されます。'
+              'データはローカルに保存され、外部に送信されることはありません。',
+              style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                    color: Colors.grey[600],
+                  ),
+            ),
+            const SizedBox(height: 8),
+            Text(
+              '統計データは1時間ごとに自動更新されます。',
+              style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                    color: Colors.grey[500],
+                    fontStyle: FontStyle.italic,
+                  ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  /// エラー状態
+  Widget _buildErrorState() {
+    return Center(
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Icon(
+            Icons.error_outline,
+            size: 64,
+            color: Colors.grey[400],
+          ),
+          const SizedBox(height: 16),
+          Text(
+            '統計データの読み込みに失敗しました',
+            style: Theme.of(context).textTheme.titleLarge?.copyWith(
+                  color: Colors.grey[600],
+                ),
+          ),
+          const SizedBox(height: 8),
+          Text(
+            'ネットワーク接続を確認して、再試行してください。',
+            style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                  color: Colors.grey[500],
+                ),
+            textAlign: TextAlign.center,
+          ),
+          const SizedBox(height: 24),
+          ElevatedButton.icon(
+            onPressed: _loadStats,
+            icon: const Icon(Icons.refresh),
+            label: const Text('再試行'),
+          ),
+        ],
+      ),
+    );
+  }
+
+  /// 日時をフォーマット
+  String _formatDateTime(DateTime dateTime) {
+    return '${dateTime.year}/${dateTime.month}/${dateTime.day} ${dateTime.hour.toString().padLeft(2, '0')}:${dateTime.minute.toString().padLeft(2, '0')}';
+  }
+
+  /// 成功スナックバーを表示
+  void _showSuccessSnackBar(String message) {
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Text(message),
+        backgroundColor: Colors.green,
+        duration: const Duration(seconds: 2),
+      ),
+    );
+  }
+
+  /// エラースナックバーを表示
+  void _showErrorSnackBar(String message) {
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Text(message),
+        backgroundColor: Colors.red,
+        duration: const Duration(seconds: 3),
+      ),
+    );
+  }
+}

--- a/lib/services/error_log_service.dart
+++ b/lib/services/error_log_service.dart
@@ -137,8 +137,7 @@ class ErrorLogService {
         await _sendOfflineLogs();
       }
 
-      debugPrint(
-          '[ErrorLogService] Logging ${enabled ? 'enabled' : 'disabled'}');
+      debugPrint('[ErrorLogService] Logging ${enabled ? 'enabled' : 'disabled'}');
     } catch (e) {
       debugPrint('[ErrorLogService] Failed to update settings: $e');
     }

--- a/lib/services/stats_dashboard_service.dart
+++ b/lib/services/stats_dashboard_service.dart
@@ -1,0 +1,469 @@
+import 'package:flutter/foundation.dart';
+import 'package:hive_flutter/hive_flutter.dart';
+import '../models/post.dart';
+import '../models/srs_card.dart';
+import '../models/review_log.dart';
+import '../services/usage_tracker.dart';
+// UsageEvent is defined in usage_tracker.dart
+
+/// ダッシュボード用の統計データ
+class DashboardStats {
+  final int totalPosts;
+  final int totalOcrCount;
+  final int completedCards;
+  final int streakDays;
+  final List<TagFrequency> topTags;
+  final List<DailyActivity> dailyActivities;
+  final List<CardProgress> cardProgress;
+  final DateTime lastUpdated;
+
+  DashboardStats({
+    required this.totalPosts,
+    required this.totalOcrCount,
+    required this.completedCards,
+    required this.streakDays,
+    required this.topTags,
+    required this.dailyActivities,
+    required this.cardProgress,
+    required this.lastUpdated,
+  });
+
+  Map<String, dynamic> toJson() => {
+        'totalPosts': totalPosts,
+        'totalOcrCount': totalOcrCount,
+        'completedCards': completedCards,
+        'streakDays': streakDays,
+        'topTags': topTags.map((e) => e.toJson()).toList(),
+        'dailyActivities': dailyActivities.map((e) => e.toJson()).toList(),
+        'cardProgress': cardProgress.map((e) => e.toJson()).toList(),
+        'lastUpdated': lastUpdated.toIso8601String(),
+      };
+
+  factory DashboardStats.fromJson(Map<String, dynamic> json) => DashboardStats(
+        totalPosts: json['totalPosts'] as int,
+        totalOcrCount: json['totalOcrCount'] as int,
+        completedCards: json['completedCards'] as int,
+        streakDays: json['streakDays'] as int,
+        topTags: (json['topTags'] as List)
+            .map((e) => TagFrequency.fromJson(e as Map<String, dynamic>))
+            .toList(),
+        dailyActivities: (json['dailyActivities'] as List)
+            .map((e) => DailyActivity.fromJson(e as Map<String, dynamic>))
+            .toList(),
+        cardProgress: (json['cardProgress'] as List)
+            .map((e) => CardProgress.fromJson(e as Map<String, dynamic>))
+            .toList(),
+        lastUpdated: DateTime.parse(json['lastUpdated'] as String),
+      );
+}
+
+/// タグの頻度データ
+class TagFrequency {
+  final String tag;
+  final int count;
+  final double percentage;
+
+  TagFrequency({
+    required this.tag,
+    required this.count,
+    required this.percentage,
+  });
+
+  Map<String, dynamic> toJson() => {
+        'tag': tag,
+        'count': count,
+        'percentage': percentage,
+      };
+
+  factory TagFrequency.fromJson(Map<String, dynamic> json) => TagFrequency(
+        tag: json['tag'] as String,
+        count: json['count'] as int,
+        percentage: (json['percentage'] as num).toDouble(),
+      );
+}
+
+/// 日別活動データ
+class DailyActivity {
+  final DateTime date;
+  final int postsCount;
+  final int ocrCount;
+  final int cardsCompleted;
+
+  DailyActivity({
+    required this.date,
+    required this.postsCount,
+    required this.ocrCount,
+    required this.cardsCompleted,
+  });
+
+  Map<String, dynamic> toJson() => {
+        'date': date.toIso8601String(),
+        'postsCount': postsCount,
+        'ocrCount': ocrCount,
+        'cardsCompleted': cardsCompleted,
+      };
+
+  factory DailyActivity.fromJson(Map<String, dynamic> json) => DailyActivity(
+        date: DateTime.parse(json['date'] as String),
+        postsCount: json['postsCount'] as int,
+        ocrCount: json['ocrCount'] as int,
+        cardsCompleted: json['cardsCompleted'] as int,
+      );
+}
+
+/// カード進捗データ
+class CardProgress {
+  final String status;
+  final int count;
+  final String color;
+
+  CardProgress({
+    required this.status,
+    required this.count,
+    required this.color,
+  });
+
+  Map<String, dynamic> toJson() => {
+        'status': status,
+        'count': count,
+        'color': color,
+      };
+
+  factory CardProgress.fromJson(Map<String, dynamic> json) => CardProgress(
+        status: json['status'] as String,
+        count: json['count'] as int,
+        color: json['color'] as String,
+      );
+}
+
+/// 統計ダッシュボードサービス
+class StatsDashboardService {
+  static const String _boxName = 'dashboard_stats';
+  static const int _cacheValidHours = 1; // 1時間キャッシュ有効
+
+  static StatsDashboardService? _instance;
+  static StatsDashboardService get instance =>
+      _instance ??= StatsDashboardService._();
+
+  StatsDashboardService._();
+
+  Box<DashboardStats>? _box;
+
+  /// 初期化
+  Future<void> initialize() async {
+    try {
+      _box = await Hive.openBox<DashboardStats>(_boxName);
+      debugPrint('[StatsDashboardService] Initialized');
+    } catch (e) {
+      debugPrint('[StatsDashboardService] Initialization failed: $e');
+    }
+  }
+
+  /// 統計データを取得（キャッシュ優先）
+  Future<DashboardStats> getStats() async {
+    try {
+      // キャッシュから取得を試行
+      final cached = await _getCachedStats();
+      if (cached != null && _isCacheValid(cached)) {
+        debugPrint('[StatsDashboardService] Using cached stats');
+        return cached;
+      }
+
+      // 新しい統計を計算
+      debugPrint('[StatsDashboardService] Computing new stats');
+      final stats = await _computeStats();
+
+      // キャッシュに保存
+      await _cacheStats(stats);
+
+      return stats;
+    } catch (e) {
+      debugPrint('[StatsDashboardService] Failed to get stats: $e');
+      return _getDefaultStats();
+    }
+  }
+
+  /// 統計データを強制更新
+  Future<DashboardStats> refreshStats() async {
+    try {
+      final stats = await _computeStats();
+      await _cacheStats(stats);
+      debugPrint('[StatsDashboardService] Stats refreshed');
+      return stats;
+    } catch (e) {
+      debugPrint('[StatsDashboardService] Failed to refresh stats: $e');
+      return _getDefaultStats();
+    }
+  }
+
+  /// 統計データを計算
+  Future<DashboardStats> _computeStats() async {
+    try {
+      // 投稿データを取得
+      final postsBox = await Hive.openBox<Post>('posts');
+      final posts = postsBox.values.toList();
+
+      // SRSカードデータを取得
+      final srsBox = await Hive.openBox<SrsCard>('srs_cards');
+      final srsCards = srsBox.values.toList();
+
+      // 学習ログデータを取得
+      final reviewBox = await Hive.openBox<ReviewLog>('review_logs');
+      final reviewLogs = reviewBox.values.toList();
+
+      // 使用統計データを取得
+      final usageBox = await Hive.openBox<UsageEvent>('usage_events');
+      final usageEvents = usageBox.values.toList();
+
+      // 基本統計を計算
+      final totalPosts = posts.length;
+      final totalOcrCount =
+          usageEvents.where((e) => e.type == UsageEventType.ocrUsed).length;
+      // 学習完了カード数を計算（ratingが高いものを完了とみなす）
+      final completedCards =
+          reviewLogs.where((r) => r.rating == '5' || r.rating == '4').length;
+
+      // 継続日数を計算
+      final streakDays = _calculateStreakDays(posts);
+
+      // トップタグを計算
+      final topTags = _calculateTopTags(posts);
+
+      // 日別活動データを計算（過去30日）
+      final dailyActivities =
+          _calculateDailyActivities(posts, usageEvents, reviewLogs);
+
+      // カード進捗を計算
+      final cardProgress = _calculateCardProgress(srsCards);
+
+      return DashboardStats(
+        totalPosts: totalPosts,
+        totalOcrCount: totalOcrCount,
+        completedCards: completedCards,
+        streakDays: streakDays,
+        topTags: topTags,
+        dailyActivities: dailyActivities,
+        cardProgress: cardProgress,
+        lastUpdated: DateTime.now(),
+      );
+    } catch (e) {
+      debugPrint('[StatsDashboardService] Failed to compute stats: $e');
+      return _getDefaultStats();
+    }
+  }
+
+  /// 継続日数を計算
+  int _calculateStreakDays(List<Post> posts) {
+    if (posts.isEmpty) return 0;
+
+    final sortedPosts = posts.toList()
+      ..sort((a, b) => b.createdAt.compareTo(a.createdAt));
+
+    int streak = 0;
+    DateTime currentDate = DateTime.now();
+
+    for (final post in sortedPosts) {
+      final postDate = DateTime(
+        post.createdAt.year,
+        post.createdAt.month,
+        post.createdAt.day,
+      );
+
+      final currentDateOnly = DateTime(
+        currentDate.year,
+        currentDate.month,
+        currentDate.day,
+      );
+
+      if (postDate.isAtSameMomentAs(currentDateOnly)) {
+        streak++;
+        currentDate = currentDate.subtract(const Duration(days: 1));
+      } else if (postDate.isBefore(currentDateOnly)) {
+        break;
+      }
+    }
+
+    return streak;
+  }
+
+  /// トップタグを計算（現在は空のリストを返す）
+  List<TagFrequency> _calculateTopTags(List<Post> posts) {
+    // TODO: Postモデルにtagsフィールドが追加されたら実装
+    return [];
+  }
+
+  /// 日別活動データを計算
+  List<DailyActivity> _calculateDailyActivities(
+    List<Post> posts,
+    List<UsageEvent> usageEvents,
+    List<ReviewLog> reviewLogs,
+  ) {
+    final activities = <DateTime, DailyActivity>{};
+    final now = DateTime.now();
+
+    // 過去30日分のデータを初期化
+    for (int i = 0; i < 30; i++) {
+      final date = now.subtract(Duration(days: i));
+      final dateOnly = DateTime(date.year, date.month, date.day);
+      activities[dateOnly] = DailyActivity(
+        date: dateOnly,
+        postsCount: 0,
+        ocrCount: 0,
+        cardsCompleted: 0,
+      );
+    }
+
+    // 投稿データを集計
+    for (final post in posts) {
+      final dateOnly = DateTime(
+        post.createdAt.year,
+        post.createdAt.month,
+        post.createdAt.day,
+      );
+
+      if (activities.containsKey(dateOnly)) {
+        activities[dateOnly] = DailyActivity(
+          date: dateOnly,
+          postsCount: activities[dateOnly]!.postsCount + 1,
+          ocrCount: activities[dateOnly]!.ocrCount,
+          cardsCompleted: activities[dateOnly]!.cardsCompleted,
+        );
+      }
+    }
+
+    // OCRデータを集計
+    for (final event in usageEvents.where(
+      (e) => e.type == UsageEventType.ocrUsed,
+    )) {
+      final dateOnly = DateTime(
+        event.timestamp.year,
+        event.timestamp.month,
+        event.timestamp.day,
+      );
+
+      if (activities.containsKey(dateOnly)) {
+        activities[dateOnly] = DailyActivity(
+          date: dateOnly,
+          postsCount: activities[dateOnly]!.postsCount,
+          ocrCount: activities[dateOnly]!.ocrCount + 1,
+          cardsCompleted: activities[dateOnly]!.cardsCompleted,
+        );
+      }
+    }
+
+    // 学習完了データを集計（ratingが高いものを完了とみなす）
+    for (final log in reviewLogs.where(
+      (r) => r.rating == '5' || r.rating == '4',
+    )) {
+      final dateOnly = DateTime(
+        log.reviewedAt.year,
+        log.reviewedAt.month,
+        log.reviewedAt.day,
+      );
+
+      if (activities.containsKey(dateOnly)) {
+        activities[dateOnly] = DailyActivity(
+          date: dateOnly,
+          postsCount: activities[dateOnly]!.postsCount,
+          ocrCount: activities[dateOnly]!.ocrCount,
+          cardsCompleted: activities[dateOnly]!.cardsCompleted + 1,
+        );
+      }
+    }
+
+    return activities.values.toList()..sort((a, b) => a.date.compareTo(b.date));
+  }
+
+  /// カード進捗を計算
+  List<CardProgress> _calculateCardProgress(List<SrsCard> srsCards) {
+    final statusCounts = <String, int>{};
+
+    for (final card in srsCards) {
+      final status = _getCardStatus(card);
+      statusCounts[status] = (statusCounts[status] ?? 0) + 1;
+    }
+
+    return statusCounts.entries
+        .map((entry) => CardProgress(
+              status: entry.key,
+              count: entry.value,
+              color: _getStatusColor(entry.key),
+            ))
+        .toList()
+      ..sort((a, b) => b.count.compareTo(a.count));
+  }
+
+  /// カードステータスを取得
+  String _getCardStatus(SrsCard card) {
+    if (card.due.isAfter(DateTime.now())) {
+      return '学習中';
+    } else if (card.repetition == 0) {
+      return '未学習';
+    } else {
+      return '復習待ち';
+    }
+  }
+
+  /// ステータス色を取得
+  String _getStatusColor(String status) {
+    switch (status) {
+      case '学習中':
+        return '#4CAF50'; // Green
+      case '未学習':
+        return '#FF9800'; // Orange
+      case '復習待ち':
+        return '#2196F3'; // Blue
+      default:
+        return '#9E9E9E'; // Grey
+    }
+  }
+
+  /// キャッシュから統計を取得
+  Future<DashboardStats?> _getCachedStats() async {
+    if (_box == null) return null;
+
+    try {
+      return _box!.get('latest');
+    } catch (e) {
+      debugPrint('[StatsDashboardService] Failed to get cached stats: $e');
+      return null;
+    }
+  }
+
+  /// 統計をキャッシュに保存
+  Future<void> _cacheStats(DashboardStats stats) async {
+    if (_box == null) return;
+
+    try {
+      await _box!.put('latest', stats);
+    } catch (e) {
+      debugPrint('[StatsDashboardService] Failed to cache stats: $e');
+    }
+  }
+
+  /// キャッシュが有効かチェック
+  bool _isCacheValid(DashboardStats stats) {
+    final now = DateTime.now();
+    final diff = now.difference(stats.lastUpdated);
+    return diff.inHours < _cacheValidHours;
+  }
+
+  /// デフォルト統計を取得
+  DashboardStats _getDefaultStats() {
+    return DashboardStats(
+      totalPosts: 0,
+      totalOcrCount: 0,
+      completedCards: 0,
+      streakDays: 0,
+      topTags: [],
+      dailyActivities: [],
+      cardProgress: [],
+      lastUpdated: DateTime.now(),
+    );
+  }
+
+  /// リソースを解放
+  Future<void> dispose() async {
+    await _box?.close();
+  }
+}

--- a/lib/widgets/stats_chart.dart
+++ b/lib/widgets/stats_chart.dart
@@ -1,0 +1,367 @@
+import 'package:flutter/material.dart';
+import 'package:fl_chart/fl_chart.dart';
+import '../services/stats_dashboard_service.dart';
+
+/// 統計チャートウィジェット
+class StatsChart extends StatelessWidget {
+  final DashboardStats stats;
+  final ChartType chartType;
+  final double height;
+
+  const StatsChart({
+    super.key,
+    required this.stats,
+    required this.chartType,
+    this.height = 200,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      height: height,
+      padding: const EdgeInsets.all(16),
+      child: _buildChart(),
+    );
+  }
+
+  Widget _buildChart() {
+    switch (chartType) {
+      case ChartType.dailyActivity:
+        return _buildDailyActivityChart();
+      case ChartType.tagFrequency:
+        return _buildTagFrequencyChart();
+      case ChartType.cardProgress:
+        return _buildCardProgressChart();
+    }
+  }
+
+  /// 日別活動チャート（棒グラフ）
+  Widget _buildDailyActivityChart() {
+    if (stats.dailyActivities.isEmpty) {
+      return _buildEmptyState('過去30日の活動データがありません');
+    }
+
+    final spots = stats.dailyActivities
+        .asMap()
+        .entries
+        .map((entry) => FlSpot(
+              entry.key.toDouble(),
+              entry.value.postsCount.toDouble(),
+            ))
+        .toList();
+
+    return LineChart(
+      LineChartData(
+        gridData: FlGridData(show: true),
+        titlesData: FlTitlesData(
+          leftTitles: AxisTitles(
+            sideTitles: SideTitles(
+              showTitles: true,
+              reservedSize: 40,
+              interval: 1,
+            ),
+          ),
+          bottomTitles: AxisTitles(
+            sideTitles: SideTitles(
+              showTitles: true,
+              reservedSize: 30,
+              interval: 5,
+              getTitlesWidget: (value, meta) {
+                if (value % 5 == 0) {
+                  final index = value.toInt();
+                  if (index < stats.dailyActivities.length) {
+                    final date = stats.dailyActivities[index].date;
+                    return Text(
+                      '${date.month}/${date.day}',
+                      style: const TextStyle(fontSize: 10),
+                    );
+                  }
+                }
+                return const Text('');
+              },
+            ),
+          ),
+          topTitles: const AxisTitles(
+            sideTitles: SideTitles(showTitles: false),
+          ),
+          rightTitles: const AxisTitles(
+            sideTitles: SideTitles(showTitles: false),
+          ),
+        ),
+        borderData: FlBorderData(show: true),
+        lineBarsData: [
+          LineChartBarData(
+            spots: spots,
+            isCurved: true,
+            color: Colors.blue,
+            barWidth: 3,
+            isStrokeCapRound: true,
+            dotData: FlDotData(show: false),
+            belowBarData: BarAreaData(
+              show: true,
+              color: Colors.blue.withValues(alpha: 0.1),
+            ),
+          ),
+        ],
+        minX: 0,
+        maxX: (stats.dailyActivities.length - 1).toDouble(),
+        minY: 0,
+        maxY: spots.isNotEmpty
+            ? spots.map((s) => s.y).reduce((a, b) => a > b ? a : b) + 1
+            : 10,
+      ),
+    );
+  }
+
+  /// タグ頻度チャート（円グラフ）
+  Widget _buildTagFrequencyChart() {
+    if (stats.topTags.isEmpty) {
+      return _buildEmptyState('タグデータがありません');
+    }
+
+    final colors = [
+      Colors.blue,
+      Colors.green,
+      Colors.orange,
+      Colors.purple,
+      Colors.red,
+    ];
+
+    final sections = stats.topTags.asMap().entries.map((entry) {
+      final index = entry.key;
+      final tag = entry.value;
+      return PieChartSectionData(
+        color: colors[index % colors.length],
+        value: tag.count.toDouble(),
+        title: '${tag.tag}\n${tag.count}',
+        radius: 80,
+        titleStyle: const TextStyle(
+          fontSize: 12,
+          fontWeight: FontWeight.bold,
+          color: Colors.white,
+        ),
+      );
+    }).toList();
+
+    return PieChart(
+      PieChartData(
+        sections: sections,
+        centerSpaceRadius: 60,
+        sectionsSpace: 2,
+        startDegreeOffset: -90,
+      ),
+    );
+  }
+
+  /// カード進捗チャート（棒グラフ）
+  Widget _buildCardProgressChart() {
+    if (stats.cardProgress.isEmpty) {
+      return _buildEmptyState('カード進捗データがありません');
+    }
+
+    final bars = stats.cardProgress.asMap().entries.map((entry) {
+      final index = entry.key;
+      final progress = entry.value;
+      final color = Color(int.parse(progress.color.replaceFirst('#', '0xFF')));
+
+      return BarChartGroupData(
+        x: index,
+        barRods: [
+          BarChartRodData(
+            toY: progress.count.toDouble(),
+            color: color,
+            width: 40,
+            borderRadius: const BorderRadius.vertical(top: Radius.circular(4)),
+          ),
+        ],
+      );
+    }).toList();
+
+    return BarChart(
+      BarChartData(
+        alignment: BarChartAlignment.spaceAround,
+        maxY: stats.cardProgress.isNotEmpty
+            ? stats.cardProgress
+                    .map((p) => p.count)
+                    .reduce((a, b) => a > b ? a : b)
+                    .toDouble() +
+                5
+            : 10,
+        titlesData: FlTitlesData(
+          leftTitles: AxisTitles(
+            sideTitles: SideTitles(
+              showTitles: true,
+              reservedSize: 40,
+              interval: 1,
+            ),
+          ),
+          bottomTitles: AxisTitles(
+            sideTitles: SideTitles(
+              showTitles: true,
+              reservedSize: 50,
+              getTitlesWidget: (value, meta) {
+                final index = value.toInt();
+                if (index < stats.cardProgress.length) {
+                  return Padding(
+                    padding: const EdgeInsets.only(top: 8),
+                    child: Text(
+                      stats.cardProgress[index].status,
+                      style: const TextStyle(fontSize: 10),
+                      textAlign: TextAlign.center,
+                    ),
+                  );
+                }
+                return const Text('');
+              },
+            ),
+          ),
+          topTitles: const AxisTitles(
+            sideTitles: SideTitles(showTitles: false),
+          ),
+          rightTitles: const AxisTitles(
+            sideTitles: SideTitles(showTitles: false),
+          ),
+        ),
+        borderData: FlBorderData(show: true),
+        barGroups: bars,
+      ),
+    );
+  }
+
+  /// 空の状態を表示
+  Widget _buildEmptyState(String message) {
+    return Center(
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Icon(
+            Icons.bar_chart,
+            size: 48,
+            color: Colors.grey[400],
+          ),
+          const SizedBox(height: 8),
+          Text(
+            message,
+            style: TextStyle(
+              color: Colors.grey[600],
+              fontSize: 14,
+            ),
+            textAlign: TextAlign.center,
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// チャートの種類
+enum ChartType {
+  dailyActivity,
+  tagFrequency,
+  cardProgress,
+}
+
+/// 統計カードウィジェット
+class StatsCard extends StatelessWidget {
+  final String title;
+  final String value;
+  final String subtitle;
+  final IconData icon;
+  final Color color;
+
+  const StatsCard({
+    super.key,
+    required this.title,
+    required this.value,
+    required this.subtitle,
+    required this.icon,
+    required this.color,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      elevation: 2,
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                Icon(icon, color: color, size: 24),
+                const SizedBox(width: 8),
+                Expanded(
+                  child: Text(
+                    title,
+                    style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                          fontWeight: FontWeight.bold,
+                        ),
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 12),
+            Text(
+              value,
+              style: Theme.of(context).textTheme.headlineMedium?.copyWith(
+                    color: color,
+                    fontWeight: FontWeight.bold,
+                  ),
+            ),
+            const SizedBox(height: 4),
+            Text(
+              subtitle,
+              style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                    color: Colors.grey[600],
+                  ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// 統計セクションウィジェット
+class StatsSection extends StatelessWidget {
+  final String title;
+  final Widget child;
+  final Widget? trailing;
+
+  const StatsSection({
+    super.key,
+    required this.title,
+    required this.child,
+    this.trailing,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                Expanded(
+                  child: Text(
+                    title,
+                    style: Theme.of(context).textTheme.titleLarge?.copyWith(
+                          fontWeight: FontWeight.bold,
+                        ),
+                  ),
+                ),
+                if (trailing != null) trailing!,
+              ],
+            ),
+            const SizedBox(height: 16),
+            child,
+          ],
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
- Add StatsDashboardService for data aggregation and caching
- Implement StatsChart widget with fl_chart integration (line, pie, bar charts)
- Create StatsDashboardPage with comprehensive learning statistics
- Add opt-in toggle in settings page with user-friendly UI
- Implement screenshot capture and SNS sharing functionality
- Support for daily activity, tag frequency, and card progress visualization
- Privacy-focused design with local data processing only
- Automatic cache management with 1-hour validity period

Features:
- Monthly post count, OCR usage, completed cards tracking
- Streak days calculation and top tags analysis
- Interactive charts with responsive design
- Screenshot sharing with formatted statistics
- Settings integration with clear privacy information